### PR TITLE
Changing app's package.json `name` to fix electron-builder issue in linux

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "safe-browser",
+  "name": "SAFEBrowser",
   "productName": "SAFEBrowser",
   "description": "A browser for the SAFE Network, powered by Beaker.",
   "homepage": "https://github.com/joshuef/beaker",


### PR DESCRIPTION
The `~/.local/share/applications/maidsafe-safe-browser.desktop` contains the following `exec` command:
`Exec=/tmp/.mount_Yb2ArI/usr/bin/SAFEBrowser %u`

But the binary generated on linux is named `safe-browser`, e.g. `/tmp/.mount_Yb2ArI/usr/bin/safe-browser`

The `electron-builder` picks the app's package.json `name` rather than the `productName`.