### PR TITLE
refactor/Removing first input param from functions with callback

### DIFF
--- a/app/lib/fg/import-web-apis.js
+++ b/app/lib/fg/import-web-apis.js
@@ -6,9 +6,9 @@ const BEAKER_VERSION = '0.0.1'
 const WITH_CALLBACK_TYPE_PREFIX = '_with_cb_';
 
 const readableToCallback = (rpcAPI) => {
-  return (arg1, arg2, cb) => {
+  return (arg1, cb) => {
     return new Promise((resolve, reject) => {
-      var r = rpcAPI(arg1, arg2);
+      var r = rpcAPI(arg1);
       r.on('data', data => cb.apply(cb, data));
       r.on('error', err => reject(err));
       r.on('end', () => resolve());


### PR DESCRIPTION
This is required by [PR #19](https://github.com/maidsafe/beaker-plugin-safe-app/pull/19) which simplifies the DOM API of the safe-app-plugin by removing the `appToken` input param from functions.