### PR TITLE
remove Rust as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ### Prerequisites
 
   * Node.js 6.5.0 (we recommend installing it via [nvm](https://github.com/creationix/nvm))
-  * Rust stable (we recommend installing it from [rust-lang.org](https://www.rust-lang.org/en-US/))
   * [Git](https://git-scm.com/)
 
 1. Clone this GitHub repository.


### PR DESCRIPTION
All the dependencies are now downloaded via pre-compiled binaries, so I think it would make sense to remove Rust as a prerequisite 🙂