### PR TITLE
fix/beaker-reloads: Stops hard reloading of beaker: pages [MAID-2141]

### DIFF
--- a/app/builtin-pages/views/downloads.js
+++ b/app/builtin-pages/views/downloads.js
@@ -13,6 +13,21 @@ import { ucfirst } from '../../lib/strings'
 
 var downloads
 
+var PAGE_TITLE = 'Downloads';
+
+// exported API
+// =
+
+//update from safe store
+function updateFromStore()
+{
+  if( document.title === PAGE_TITLE )
+  {
+    getDownloads( render )
+  }
+};
+
+
 // exported API
 // =
 
@@ -23,12 +38,19 @@ export function setup () {
   dlEvents.on('done', onUpdate)
 }
 
-export function show () {
-  document.title = 'Downloads'
+function getDownloads( cb )
+{
   co(function* () {
     downloads = yield beakerDownloads.getDownloads()
-    render()
+    cb()
   })
+}
+
+export function show () {
+  document.title = PAGE_TITLE;
+  getDownloads( render );
+
+  window.updateFromStore = updateFromStore;
 }
 
 export function hide () {

--- a/app/builtin-pages/views/favorites.js
+++ b/app/builtin-pages/views/favorites.js
@@ -10,24 +10,42 @@ import co from 'co'
 
 // bookmarks, cached in memory
 var bookmarks = []
-
+var PAGE_TITLE = 'Favorites';
 
 // exported API
 // =
+
+//update from safe store
+function updateFromStore()
+{
+  if( document.title === PAGE_TITLE )
+  {
+    getBookmarks( render )
+  }
+};
+
+
+function getBookmarks( cb )
+{
+  co(function*() {
+    // get the bookmarks, ordered by # of views
+    bookmarks = yield beakerBookmarks.list()
+    bookmarks = bookmarks || []
+
+    cb()
+  })
+}
+
 
 export function setup () {
 }
 
 export function show () {
 
-  document.title = 'Favorites'
-  co(function*() {
-    // get the bookmarks, ordered by # of views
-    bookmarks = yield beakerBookmarks.list()
-    bookmarks = bookmarks || []
+  document.title = PAGE_TITLE;
+  window.updateFromStore = updateFromStore;
 
-    render()
-  })
+  getBookmarks( render );
 }
 
 export function hide () {

--- a/app/builtin-pages/views/history.js
+++ b/app/builtin-pages/views/history.js
@@ -16,6 +16,7 @@ const BEGIN_LOAD_OFFSET = 500
 // visits, cached in memory
 var visits = []
 var isAtEnd = false
+var PAGE_TITLE = 'History'
 
 // exported API
 // =
@@ -23,9 +24,21 @@ var isAtEnd = false
 export function setup () {
 }
 
+
+//update from safe store
+function updateFromStore()
+{
+  if( document.title === PAGE_TITLE )
+  {
+    fetchMore( render )
+  }
+};
+
 export function show () {
-  document.title = 'History'
+  document.title = PAGE_TITLE
   fetchMore(render)
+
+  window.updateFromStore = updateFromStore;
 }
 
 export function hide () {

--- a/app/builtin-pages/views/settings.js
+++ b/app/builtin-pages/views/settings.js
@@ -14,25 +14,42 @@ var browserInfo
 var browserEvents
 var defaultProtocolSettings
 
+var PAGE_TITLE = 'Settings'
 // exported API
 // =
+
+//update from safe store
+function updateFromStore()
+{
+  if( document.title === PAGE_TITLE )
+  {
+    updateSettings( render )
+  }
+};
+
+function updateSettings( cb )
+{
+  co(function* () {
+    browserInfo = yield beakerBrowser.getInfo()
+    settings = yield beakerBrowser.getSettings()
+    defaultProtocolSettings = yield beakerBrowser.getDefaultProtocolSettings()
+
+    cb()
+  })
+}
 
 export function setup () {
   // wire up events
   browserEvents = emitStream(beakerBrowser.eventsStream())
   browserEvents.on('updater-state-changed', onUpdaterStateChanged)
   browserEvents.on('updater-error', onUpdaterError)
+
 }
 
 export function show () {
-  document.title = 'Settings'
-  co(function* () {
-    browserInfo = yield beakerBrowser.getInfo()
-    settings = yield beakerBrowser.getSettings()
-    defaultProtocolSettings = yield beakerBrowser.getDefaultProtocolSettings()
-
-    render()
-  })
+  document.title = PAGE_TITLE;
+  updateSettings( render );
+  window.updateFromStore = updateFromStore;
 }
 
 export function hide () {

--- a/app/shell-window/pages.js
+++ b/app/shell-window/pages.js
@@ -264,20 +264,25 @@ export function create (opts) {
 }
 
 
-function handleStoreChange() {
+function triggerBeakerPageUpdates() {
   var page = getAll();
 
   pages.forEach( page =>
   {
     if( page.isWebviewReady && page.getURL().includes('beaker:') )
-  {
-    page.reload()
-  }
-})
+    {
+      //lets execute updateFromStore to reload the page.
+      page.webviewEl.executeJavaScript(
+        `if( typeof window.updateFromStore !== 'undefined' )
+        {
+          window.updateFromStore();
+        }`)
+    }
+  })
 }
 
 
-export const handleSafeStoreChange = _.debounce( handleStoreChange, 200 );
+export const handleSafeStoreChange = _.debounce( triggerBeakerPageUpdates, 200 );
 
 
 


### PR DESCRIPTION
When the store updates, there's no longer a hard reload.

Instead pages get window.updateFromStore methods triggered inside the page.