### PR TITLE
fix/osx-store: Ubsubscribe on close [MAID-2287]

### DIFF
--- a/app/background-process.js
+++ b/app/background-process.js
@@ -40,6 +40,7 @@ const parseSafeUri = function(uri) {
   return uri.replace('//', '').replace('==/', '==');
 };
 
+global.windowStoreUnsubscribers = {};
 
 // // configure logging
 log.setLevel('trace')
@@ -105,7 +106,15 @@ app.on('ready', function () {
 })
 
 app.on('window-all-closed', function () {
-  global.unsubscribeFromSafeStore();
+  let allUnsubscribers = global.windowStoreUnsubscribers;
+
+  Object.values( allUnsubscribers ).forEach( unSubscriber =>
+  {
+    unSubscriber();
+  });
+
+  // reset the obj
+  global.windowStoreUnsubscribers = {};
 
   if (process.platform !== 'darwin')
     app.quit()

--- a/app/background-process.js
+++ b/app/background-process.js
@@ -105,6 +105,8 @@ app.on('ready', function () {
 })
 
 app.on('window-all-closed', function () {
+  global.unsubscribeFromSafeStore();
+
   if (process.platform !== 'darwin')
     app.quit()
 })

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -153,13 +153,15 @@ export function createShellWindow () {
 
   let previousNetworkStatus = null;
 
-  store.subscribe( e =>
+  let unsubscribeFromStore = store.subscribe( () =>
   {
     let newState = store.getState();
     logInRenderer( store.getState() );
     win.webContents.send('safeStore-updated')
 
-  })
+  });
+
+  global.unsubscribeFromSafeStore = unsubscribeFromStore;
 
 
 

--- a/app/background-process/ui/windows.js
+++ b/app/background-process/ui/windows.js
@@ -161,7 +161,8 @@ export function createShellWindow () {
 
   });
 
-  global.unsubscribeFromSafeStore = unsubscribeFromStore;
+  global.windowStoreUnsubscribers[ win.webContents.id ] =  unsubscribeFromStore;
+
 
 
 


### PR DESCRIPTION
 all windows to prevent object destroyed warnings.

(Webcontents was, obv, being destroyed, but the listener was in place)