### PR TITLE
readd NODE_ENV=dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
   * Node.js 6.5.0 (we recommend installing it via [nvm](https://github.com/creationix/nvm))
   * [Git](https://git-scm.com/)
-  * [Yarn](https://yarnpkg.com) (As a replacement for `npm`).
+  * [Yarn](https://yarnpkg.com) (as a replacement for `npm`).
 
 
 1. Clone this GitHub repository.
@@ -26,6 +26,8 @@
     $ yarn
     ```
 
+    If you are working on a development environment, you can run `NODE_ENV=dev yarn` instead in order to get the `safe_client` libraries which use the `MockVault` file rather than connecting to the SAFE Network.
+
 3. Build SAFE Browser and open it.
 
     ```
@@ -37,9 +39,9 @@
 
 6. Package SAFE Browser.
 
-   ```
-   $ yarn run package
-   ```
+    ```
+    $ yarn run package
+    ```
 
     The packed SAFE Browser will be found inside `dist` folder.
 
@@ -50,10 +52,11 @@ If you pull latest from the repo and get weird module errors, do:
 ```bash
 $ yarn run burnthemall
 ```
-This will remove your node_modules, and do the full install, rebuild, build SAFE Authenticator and package  processes for you. `yarn start` should work afterwards.
+
+This will remove your node_modules, and do the full install, rebuild, build SAFE Authenticator and package processes for you. `yarn start` should work afterwards.
 
 ## License
 
-SAFE Browser is a lightly modified fork of the [beaker browser](https://www.beakerbrowser.com/).
+SAFE Browser is a lightly modified fork of the [Beaker Browser](https://www.beakerbrowser.com/).
 
 Modified MIT as per the [BeakerLicense](https://github.com/maidsafe/safe_browser/blob/master/BEAKER_LICENSE.md)


### PR DESCRIPTION
The instructions that explain how to build the SAFE Browser for mock-routing were removed in [this commit](https://github.com/maidsafe/safe_browser/commit/89e8e199d116f07acf63a7cc34c0a9020fc72af6#diff-04c6e90faac2675aa89e2176d2eec7d8).

I think it could be good to readd them 🙂