### PR TITLE
Resolve resource fetch issue

### DIFF
--- a/app/shell-window/ui/navbar.js
+++ b/app/shell-window/ui/navbar.js
@@ -931,7 +931,8 @@ function onKeydownLocation (e) {
       }
 
       var selectionUrl = selection.url
-
+      selectionUrl = selectionUrl.replace(/\/?(\?|#|$)/, '/$1');
+      
       page.loadURL(selectionUrl, { isGuessingTheScheme: selection.isGuessingTheScheme })
       e.target.blur()
     }


### PR DESCRIPTION
Fetch images with relative path breaks within subfolders, when the address was given without `index.html`. eg `safe://service.publicname/subDir`. 
Fixed this issue.