### PR TITLE
feat/CI: Add mock to travis builds & update for new build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ dist: trusty
 os:
 - osx
 - linux
+
+
+env:
+- NODE_ENV=dev
+- NODE_ENV=prod
+
+
 node_js:
 - node
 cache:
@@ -20,39 +27,27 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
-before_script:
-- export NODE_ENV=production
 script:
 - yarn build
 - yarn package
 before_deploy:
 - ls dist
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mv dist/*.dmg dist/safe-browser-${TRAVIS_TAG}-osx-x64.dmg;
+- export DIST_FOLDER="$(ls dist)";
+- zip -r -q dist/$(ls dist).zip dist/$(ls dist);
+- rm -rf dist/$DIST_FOLDER
+- if [[ "$NODE_ENV" == "dev" ]]; then mv dist/{,mock-}$(ls dist);
   fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export RELEASE_PKG=$(ls dist/*.dmg);
-  fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mv dist/*.zip dist/safe-browser-${TRAVIS_TAG}-linux-x64.zip;
-  fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then rm -rf dist/linux-unpacked;
-  fi
-- ls
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export RELEASE_PKG="$(ls dist/safe*)";
-  fi
-- echo "deploying ${RELEASE_PKG} to GitHub releases"
+- ls dist
+- export RELEASE_DIR="$(ls dist/*.zip)";
+- echo "deploying ${RELEASE_DIR} to GitHub releases as tagged with ${TRAVIS_TAG}"
 deploy:
   provider: releases
   skip_cleanup: true
   api_key:
     secure: dNUJgCh8UYnwLH09f7W3Wu/ZhO2wPBHkFlN8Z9n5uIXm1CH/FkZl6uqBZ1LTUov6K1kqhlDTpJvKd2lbQkYkbMcLqa5LN3vrXiJX0jmTmoIz4ujSpYcKeSfMSc8S7NBI4/w+hD6Z8d+3fUwNlQgZjrSQbkabpm/zmE7ShGGu9VjmrCXXGDWOxRBLWVP6ujzLTuLns2kC1gdtz7p7ceeZ5flXe24iSc4O8TZhUJkuC3vLvUuLiTfSoWAbtwNXZ1mjIj45M7cixTpsAyBmduEH6X/o2fCy8AuFuRTNHo24u0t1jie0OyVXqyDOVVQ+cIvzvgQCiyCljbx7ZxnOKum/PJ0QchkWSX6b9R14+EIPDiNDpshBrul+SKQDWlfKYkCpcQVsEIJrENuUpynrNZx8rQ41EF1d/uqpWAgBNG78MprqZ+9jZR+XSrz7zPn4/iBH3GZjtkwlRCm81exyF6jJypVyPkUFHh0npPRzoFdk6CR3ywk0EsSa6vWR04E2HzZBvBs5MOk2UHM5G7NUAsXLo3JGp1aLsBgU0+C2SIjmyvfielEKzUgmhLZFCItAada92QcEJU/6ekjGwL1uxVO7mqVth3iRatHS7Dk6x9t92rXNPihW7h0qGpA+Skg7PXTBP6QiIPOA4fAFzpG6GcDu4RWZnUPxBQluIvcnJdPwemw=
-  file: "${RELEASE_PKG}"
+  file: "${RELEASE_DIR}"
   draft: true
   tag_name: $TRAVIS_TAG
   on:
     all_branches: true
     tag: true
-notifications:
-  email:
-    on_success:
-    - change
-    on_failure:
-    - change

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,9 @@ image: Visual Studio 2017
 os: unstable
 environment:
   nodejs_version: "Stable"
-
+  matrix:
+    - NODE_ENV: "dev"
+    - NODE_ENV: "production"
 cache:
   - "%LOCALAPPDATA%\\Yarn"
   - node_modules
@@ -34,17 +36,14 @@ build_script:
 after_build:
   - ps: Get-ChildItem .\*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
   - dir dist
-  - echo dist\safe-browser-%APPVEYOR_REPO_TAG_NAME%-win
   - cd dist
-  - dir
-  - rename win-unpacked safe-browser-%APPVEYOR_REPO_TAG_NAME%-win-x64
   - 7z a safe-browser-%APPVEYOR_REPO_TAG_NAME%-win-x64.zip
   - dir
   - echo %APPVEYOR_REPO_TAG%
   - echo %APPVEYOR_REPO_TAG_NAME%
 
 artifacts:
-  - path: dist/*.zip
+  - path: dist/*
 
 before_deploy:
     # - dir dist
@@ -61,6 +60,6 @@ deploy:
   draft: true
   prerelease: true
   on:
-    branch: PackagingProcess
+    branch: AddMockTravisBuild
     appveyor_repo_tag:  true        # deploy on tag push only
     # appveyor_repo_tag:  true        # deploy on tag push only


### PR DESCRIPTION
Adds osx/linux builds for release/mock.

Windows is partially there, working for prod, but naming is still creating a zip with the tag, where it doesn't need to; also there's no conditional prefix of `mock-` yet.