### PR TITLE
Issue #277 chore/styles: cleans up auth request notificaiton to only show details on hover

### DIFF
--- a/app/app.global.css
+++ b/app/app.global.css
@@ -27,3 +27,14 @@ html
     font-size: 62.5%;
     line-height: 1.2em;
 }
+
+.info_box_details
+{
+    display: none;
+    margin-top: 5%;
+}
+
+.info_box_expander:hover + .info_box_details
+{
+    display: block;
+}

--- a/app/components/Notifier/Notifier.jsx
+++ b/app/components/Notifier/Notifier.jsx
@@ -120,7 +120,7 @@ export default class Notifier extends Component
         return (
             <Row hasMinHeight className={ styles.container }>
                 <MessageBox messageType={type}>
-                    <Row verticalAlign="middle" align="center">
+                    <Row verticalAlign="top" align="center">
                         <Column key="notifier-text" align="left">
                           {
                             reactNode && reactElement
@@ -132,17 +132,17 @@ export default class Notifier extends Component
                         </Column>
                         {
                             handleOnAccept &&
-                            <Column key="notifier-accept" align="left">
+                            <Column verticalAlign="top" key="notifier-accept" align="right">
                                 <Button role="promoted" onClick={ handleOnAccept }>{ acceptText }</Button>
                             </Column>
                         }
                         {
                             handleOnDeny &&
-                            <Column key="notifier-deny" align="left">
+                            <Column verticalAlign="top" key="notifier-deny" align="right">
                                 <Button onClick={ handleOnDeny }>{ denyText }</Button>
                             </Column>
                         }
-                        <Column key="notifier-dismiss" align="left">
+                        <Column verticalAlign="top" key="notifier-dismiss" align="right">
                             <IconButton
                                 role="subtle"
                                 iconType="close"

--- a/app/extensions/safe/components/authRequest.js
+++ b/app/extensions/safe/components/authRequest.js
@@ -3,6 +3,8 @@ import logger from 'logger';
 // TODO: When I import the following, an error is thrown in CodeMirror, used by nessie-ui, that navigator is not defined
 //import { Text, Column } from 'nessie-ui';
 
+//import './authRequest.css';
+
 export const createAuthRequestElement = (authReqData) =>
 {
     let reqType = 'authReq';
@@ -24,22 +26,25 @@ export const createAuthRequestElement = (authReqData) =>
       {
         return (
           <div>
-             <p className='blockText' key='Requested containers:'>Requested containers:</p>
-             {
-               authReqData[reqType].containers.map((container) => {
-                 return (
-                   <div>
-                     <p className='blockText' key={container.cont_name}>{container.cont_name}</p>
-                     <ul key={container.cont_name + '_ul'}>
-                       {
-                         Object.keys(container.access).filter((permission) => container.access[permission]).map((permission) => <li key={container.cont_name + '_' + permission}>{permission}</li>)
-                       }
-                     </ul>
-                   </div>
-                 );
-               })
-             }
-          </div>
+            <a key='info_box_expander' className='info_box_expander'>Details</a>
+            <div key='info_box_details' className='info_box_details'>
+               <p className='blockText' key='Requested containers:'>Requested containers:</p>
+               {
+                 authReqData[reqType].containers.map((container) => {
+                   return (
+                     <div>
+                       <p className='blockText' key={container.cont_name}>{container.cont_name}</p>
+                       <ul key={container.cont_name + '_ul'}>
+                         {
+                           Object.keys(container.access).filter((permission) => container.access[permission]).map((permission) => <li key={container.cont_name + '_' + permission}>{permission}</li>)
+                         }
+                       </ul>
+                     </div>
+                   );
+                 })
+               }
+            </div>
+          </div> 
         ); 
       }
       return (<div></div>);
@@ -50,25 +55,28 @@ export const createAuthRequestElement = (authReqData) =>
       {
         return (
           <div>
-            <p className='blockText' key='Requested Mutable Data:'>Requested Mutable Data:</p>
-            {
-              authReqData[reqType].mdata.map((mdatum, i) => {
-                const metaName = authReqData.metaData[i].name;
-                const metaDesc = authReqData.metaData[i].description;
-                return (
-                  <div>
-                    <p key={metaName + i}>{metaName}</p>
-                    <p key={metaDesc + i}>{metaDesc}</p>
-                    <p key={metaName + mdatum.type_tag + i}>{mdatum.type_tag}</p>
-                    <p key={'Permissions:' + i}>Permissions:</p>
-                    {
-                      Object.keys(mdatum.perms).filter((perm) => mdatum.perms[perm]).map((perm, i) => <p key={metaName + perm + i}>{perm}</p>)
-                    }
-                  </div>
-                );
-              })
-            } 
-          </div> 
+            <a key='info_box_expander' className="info_box_expander">Details</a>
+            <div key='info_box_details' className="info_box_details">
+              <p className='blockText' key='Requested Mutable Data:'>Requested Mutable Data:</p>
+              {
+                authReqData[reqType].mdata.map((mdatum, i) => {
+                  const metaName = authReqData.metaData[i].name;
+                  const metaDesc = authReqData.metaData[i].description;
+                  return (
+                    <div>
+                      <p key={metaName + i}>{metaName}</p>
+                      <p key={metaDesc + i}>{metaDesc}</p>
+                      <p key={metaName + mdatum.type_tag + i}>{mdatum.type_tag}</p>
+                      <p key={'Permissions:' + i}>Permissions:</p>
+                      {
+                        Object.keys(mdatum.perms).filter((perm) => mdatum.perms[perm]).map((perm, i) => <p key={metaName + perm + i}>{perm}</p>)
+                      }
+                    </div>
+                  );
+                })
+              } 
+            </div> 
+          </div>
         );
       }
       return (<div></div>);


### PR DESCRIPTION
@joshuef At first I tried placing the styles in `notifier.css`, where I noticed them not loaded when `Notifier` is rendered. There are absolutely no styles that will take effect from `notifier.css`. What is that about?

I then tried placing styles in `authReqest.css` and importing it in `authRequest.js`, for which I get parsing error related to babel, which I don't understand yet because the config in `webpack.config.base.js` looks just fine.