### PR TITLE
fix/safe-protocol: peruse was defaulting urls with no subdomain to www.<hostname>

### DIFF
--- a/app/extensions/safe/protocols/safe.js
+++ b/app/extensions/safe/protocols/safe.js
@@ -23,11 +23,6 @@ const registerSafeProtocol = () =>
             return;
         }
 
-        if ( host.indexOf( '.' ) < 1 )
-        {
-            host = `www.${parsedUrl.host}`;
-        }
-
         const path = parsedUrl.pathname || '';
 
         // TODO. Sort out when/where with slash


### PR DESCRIPTION
Peruse shouldn't be trying to default a URL with no subdomain as that's handled by the underlying `webFetch` function, specially because this could be changed in the future and it's not the browser responsibility.