### PR TITLE
chore/bump: safe-app-nodejs bumped to latest dev branch version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@maidsafe/safe-node-app": "git+https://github.com/maidsafe/safe_app_nodejs#c722378eca56b5cc6738d87a0a32db763914d000",
+    "@maidsafe/safe-node-app": "git+https://github.com/maidsafe/safe_app_nodejs#338ec368e25eb2e258d2447413006d74ecc23a15",
     "cross-env": "5.1.3",
     "enum": "2.5.0",
     "ffi": "2.2.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@maidsafe/safe-node-app@git+https://github.com/maidsafe/safe_app_nodejs#c722378eca56b5cc6738d87a0a32db763914d000":
-  version "0.9.0"
-  resolved "git+https://github.com/maidsafe/safe_app_nodejs#c722378eca56b5cc6738d87a0a32db763914d000"
+"@maidsafe/safe-node-app@git+https://github.com/maidsafe/safe_app_nodejs#338ec368e25eb2e258d2447413006d74ecc23a15":
+  version "0.9.1"
+  resolved "git+https://github.com/maidsafe/safe_app_nodejs#338ec368e25eb2e258d2447413006d74ecc23a15"
   dependencies:
     cross-env "5.1.3"
     deps_downloader "https://s3.eu-west-2.amazonaws.com/deps-downloader/deps_downloader-0.2.0.tgz"


### PR DESCRIPTION
Solves this issue in the web-id-manager: https://github.com/maidsafe/safe-web-id-manager-js/issues/7