### PR TITLE
fix(UI): when the app name is just - or _ characters render them in the authenticator as they are

### DIFF
--- a/app/extensions/safe/auth-web-app/utils.js
+++ b/app/extensions/safe/auth-web-app/utils.js
@@ -80,6 +80,10 @@ export const parseErrCode = ( errStr ) =>
 
 export const parseAppName = (name) => {
   const parsedName = name.replace(/-|_/g, ' ');
+  // if the app's name it's just a sequence
+  // of '-' and/or '_' chars, then return it as is
+  if (parsedName.trim().length === 0) return name;
+
   return parsedName.split(' ').map((i) => `${i[0].toUpperCase()}${i.slice(1)}`).join(' ');
 };
 


### PR DESCRIPTION
Minor fix for an unlikely but possible case when the application's name is just a sequence of `-` and/or `_` characters. In such don't replace theses characters with white spaces. This was causing the whole authenticator page to be a blank screen.

To reproduce it you can authorise an app with the following info and then go to the authenticator tab to see a blank page:
```
window.safe.initialiseApp({
    id: 'net.maidsafe.test.webapp.id',
    name: '-',
    vendor: 'MaidSafe Ltd.'
  });
```