### PR TITLE
[WIP] fix(reconnect): stabilises reconnection and reloading handling

### DIFF
--- a/app/components/AddressBar/AddressBar.jsx
+++ b/app/components/AddressBar/AddressBar.jsx
@@ -51,7 +51,7 @@ export default class AddressBar extends Component
     handleBack = ( ) =>
     {
         const { activeTabBackwards, windowId } = this.props;
-        activeTabBackwards( windowId );
+        activeTabBackwards( { windowId } );
     }
 
     handleForward = ( ) =>

--- a/app/components/Notifier/Notifier.jsx
+++ b/app/components/Notifier/Notifier.jsx
@@ -8,23 +8,22 @@ import logger from 'logger';
 import { CLASSES } from 'appConstants';
 
 import { Button, Column, IconButton, MessageBox, Row, Text } from 'nessie-ui';
+import extendComponent from 'utils/extendComponent';
+import { wrapNotifier } from 'extensions/components';
 
 const log = require( 'electron-log' );
 
-export default class Notifier extends Component
+class Notifier extends Component
 {
     static propTypes =
    {
-       isVisible   : PropTypes.bool,
-       text        : PropTypes.string,
-       type        : PropTypes.string,
-       acceptText  : PropTypes.string,
-       denyText    : PropTypes.string,
-       dismissText : PropTypes.string,
-       onDismiss   : PropTypes.string,
-       onAccept    : PropTypes.string,
-       onDeny      : PropTypes.string,
-       reactNode    : PropTypes.object,
+       isVisible          : PropTypes.bool,
+       text               : PropTypes.string,
+       type               : PropTypes.string,
+       acceptText         : PropTypes.string,
+       denyText           : PropTypes.string,
+       dismissText        : PropTypes.string,
+       reactNode          : PropTypes.object,
        updateNotification : PropTypes.func
    }
     static defaultProps =
@@ -178,3 +177,5 @@ export default class Notifier extends Component
         );
     }
 }
+
+export default extendComponent( Notifier, wrapNotifier );

--- a/app/components/TabContents/TabContents.jsx
+++ b/app/components/TabContents/TabContents.jsx
@@ -110,6 +110,8 @@ export default class TabContents extends Component
                     focusWebview={ focusWebview }
                     shouldFocusWebview={ shouldFocusWebview }
                     activeTabBackwards={ activeTabBackwards }
+                    shouldReload={ tab.shouldReload }
+                    history={ tab.history }
                     ref={ ( c ) =>
                     {
                         if ( isActiveTab )

--- a/app/extensions/components.js
+++ b/app/extensions/components.js
@@ -6,12 +6,14 @@ import {
 import safeWrapAddressBarButtonsLHS from 'extensions/safe/components/wrapAddressBarButtonsLHS';
 import safeWrapAddressBarButtonsRHS from 'extensions/safe/components/wrapAddressBarButtonsRHS';
 import safeWrapAddressBarInput from 'extensions/safe/components/wrapAddressBarInput';
+import safeWrapNotifier from 'extensions/safe/components/wrapNotifier';
 
 
 const allBrowserExtensions = [safeWrapBrowser];
 const allAddressBarButtonLHSExtensions = [safeWrapAddressBarButtonsLHS];
 const allAddressBarButtonRHSExtensions = [safeWrapAddressBarButtonsRHS];
 const allAddressBarInputExtensions = [safeWrapAddressBarInput];
+const allNotifierExtensions = [safeWrapNotifier];
 
 /**
  * Wrap the browser with a HOC or replace it entirely.
@@ -124,6 +126,34 @@ export const wrapAddressBarInput = ( AddressBarInput ) =>
     catch ( e )
     {
         console.error( 'Problem with extension wrapping of Addressbar input component' );
+        throw new Error( e );
+    }
+};
+
+/**
+ * Wrap the Notifier component.
+ *
+ * This is separate to the extensions/index file to prevent pulling in libs which will break tests
+ *
+ * @param  {React Component} Notifier react component
+ */
+export const wrapNotifier = ( Notifier ) =>
+{
+    try
+    {
+        logger.verbose( 'Wrapping Address bar input' );
+        let WrapNotifier = Notifier;
+
+        allNotifierExtensions.forEach( wrapper =>
+        {
+            WrapNotifier = wrapper( Notifier );
+        } );
+
+        return WrapNotifier;
+    }
+    catch ( e )
+    {
+        console.error( 'Problem with extension wrapping of Notifier component' );
         throw new Error( e );
     }
 };

--- a/app/extensions/safe/actions/safeBrowserApplication_actions.js
+++ b/app/extensions/safe/actions/safeBrowserApplication_actions.js
@@ -1,5 +1,7 @@
 import { createActions } from 'redux-actions';
 import { createAliasedAction } from 'electron-redux';
+import { attemptReconnect } from 'extensions/safe/network';
+import { getSafeBrowserAppObject, getCurrentStore } from 'extensions/safe/safeBrowserApplication';
 import getWebIdsFromSafe from 'extensions/safe/safeBrowserApplication/webIds';
 import logger from 'logger';
 
@@ -7,6 +9,7 @@ export const TYPES = {
     SET_APP_STATUS     : 'SET_APP_STATUS',
     SET_NETWORK_STATUS : 'SET_NETWORK_STATUS',
     SET_IS_MOCK        : 'SET_IS_MOCK',
+    RECONNECT          : 'RECONNECT',
 
     // experiments
     ENABLE_EXPERIMENTS  : 'ENABLE_EXPERIMENTS',
@@ -27,7 +30,8 @@ export const TYPES = {
     RESET_STORE        : 'RESET_STORE',
 
     // UI actions.
-    SHOW_WEB_ID_DROPDOWN : 'SHOW_WEB_ID_DROPDOWN'
+    SHOW_WEB_ID_DROPDOWN : 'SHOW_WEB_ID_DROPDOWN',
+    SET_IS_CONNECTING    : 'SET_IS_CONNECTING'
 };
 
 export const {
@@ -50,7 +54,8 @@ export const {
 
     resetStore,
 
-    showWebIdDropdown
+    showWebIdDropdown,
+    setIsConnecting
 } = createActions(
     TYPES.SET_APP_STATUS,
     TYPES.SET_NETWORK_STATUS,
@@ -70,7 +75,8 @@ export const {
     TYPES.RECONNECT_SAFE_APP,
     TYPES.RESET_STORE,
 
-    TYPES.SHOW_WEB_ID_DROPDOWN
+    TYPES.SHOW_WEB_ID_DROPDOWN,
+    TYPES.SET_IS_CONNECTING
 );
 
 
@@ -91,4 +97,21 @@ export const getAvailableWebIds = createAliasedAction(
             type    : TYPES.GET_AVAILABLE_WEB_IDS,
             payload : triggerGetWebIds(),
         } ),
+);
+
+export const reconnect = createAliasedAction(
+    TYPES.RECONNECT,
+    () =>
+        (
+            {
+            // the real action
+                type    : TYPES.RECONNECT,
+                payload : attemptReconnect(
+                    getCurrentStore(),
+                    getSafeBrowserAppObject(),
+                    null,
+                    true
+                )
+            }
+        )
 );

--- a/app/extensions/safe/components/wrapNotifier.js
+++ b/app/extensions/safe/components/wrapNotifier.js
@@ -1,0 +1,105 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { reconnect } from '../actions/safeBrowserApplication_actions';
+import { Button, Spin } from 'antd';
+import 'antd/lib/button/style';
+import 'antd/lib/spin/style';
+import PropTypes from 'prop-types';
+import logger from 'logger';
+import './wrapNotifier.less'
+
+function mapStateToProps( state )
+{
+    return {
+        isConnecting : state.safeBrowserApp.isConnecting
+    };
+}
+
+function mapDispatchToProps( dispatch )
+{
+    const actions =
+        {
+            reconnect
+        };
+    return bindActionCreators( actions, dispatch );
+}
+
+
+const wrapNotifier = ( Notifier, extensionFunctionality = {} ) =>
+{
+    class WrapNotifier extends Component
+    {
+        constructor()
+        {
+            super();
+            this.state = { countdown: 0 };
+        }
+
+        componentWillReceiveProps( nextProps )
+        {
+            const { countdown } = this.state;
+            if ( nextProps.handleReconnect && countdown <= 0 )
+            {
+                const fifteenSecs = Date.now() + 15000;
+
+                const intervalID = setInterval( () =>
+                {
+                    const currentSecs = Date.now();
+                    const remainingMs = fifteenSecs - currentSecs;
+                    const remainingSecs = Math.ceil( remainingMs / 1000 );
+                    this.setState( { countdown: remainingSecs } );
+                    if ( remainingSecs <= 0 )
+                    {
+                        clearInterval( intervalID );
+                    }
+                }, 1000 );
+            }
+        }
+
+        render()
+        {
+            const { handleReconnect, reconnect, isConnecting } = this.props;
+            const { countdown } = this.state;
+
+            return (
+                <div>
+                    <Notifier
+                        { ...this.props }
+                    />
+                    { handleReconnect &&
+                        <div
+                            className="container"
+                        >
+                            <Button
+                                type="default"
+                                size="large"
+                                loading={ isConnecting }
+                                onClick={ () =>
+                                {
+                                    if ( !isConnecting )
+                                    {
+                                        return reconnect()
+                                    }
+                                } }
+                            >
+                                { !isConnecting && countdown > 0 &&
+                                    `Reconnecting in ${countdown} seconds`
+                                }
+                                { countdown <= 0 &&
+                                    'Reconnect'
+                                }
+                            </Button>
+                        </div>
+                    }
+                </div>
+            );
+        }
+    }
+
+    const hookedUpInput = connect( mapStateToProps, mapDispatchToProps )( WrapNotifier );
+
+    return hookedUpInput;
+};
+
+export default wrapNotifier;

--- a/app/extensions/safe/components/wrapNotifier.less
+++ b/app/extensions/safe/components/wrapNotifier.less
@@ -1,0 +1,9 @@
+.container
+{
+    flex: 0 0 0%;
+    position: absolute;
+    z-index: 3;
+    top: 13.5rem;
+    width: 100%;
+    font-size: 1.4rem;
+}

--- a/app/extensions/safe/menus.js
+++ b/app/extensions/safe/menus.js
@@ -7,46 +7,41 @@ import { SAFE } from 'extensions/safe/constants';
 import logger from 'logger';
 
 const safeSave = ( store ) => (
-{
-    label       : 'Save Browser State to SAFE',
-    accelerator : 'CommandOrControl+Shift+E',
-    click       : ( item, win ) =>
     {
-        if ( win )
+        label       : 'Save Browser State to SAFE',
+        accelerator : 'CommandOrControl+Shift+E',
+        click       : ( item, win ) =>
         {
-            store.dispatch( setSaveConfigStatus( SAFE.SAVE_STATUS.TO_SAVE ) )
-
+            if ( win )
+            {
+                store.dispatch( setSaveConfigStatus( SAFE.SAVE_STATUS.TO_SAVE ) );
+            }
         }
-    }
-});
+    } );
 
 const safeRead = ( store ) => (
-{
-    label       : 'Read Browser State from SAFE',
-    accelerator : 'CommandOrControl+Alt+F',
-    click       : ( item, win ) =>
     {
-        if ( win )
+        label       : 'Read Browser State from SAFE',
+        accelerator : 'CommandOrControl+Alt+F',
+        click       : ( item, win ) =>
         {
-            store.dispatch( setReadConfigStatus( SAFE.READ_STATUS.TO_READ ) )
+            if ( win )
+            {
+                store.dispatch( setReadConfigStatus( SAFE.READ_STATUS.TO_READ ) );
+            }
         }
-    }
-} );
-
+    } );
 
 export const addFileMenus = ( store, menu ) =>
 {
-    if( !store || typeof store !== 'object' ) throw new Error ( 'Must pass the store to enable dispatching actions from the menus.')
+    if ( !store || typeof store !== 'object' ) throw new Error( 'Must pass the store to enable dispatching actions from the menus.' );
 
-    if( !menu  ) throw new Error ( 'Must pass a menu to extend.')
+    if ( !menu ) throw new Error( 'Must pass a menu to extend.' );
 
-    const save = safeSave(store);
-    const read = safeRead(store);
+    const newMenu = { ...menu };
 
-    const newMenu = { ...menu }
-
-    newMenu.submenu.push( { type: 'separator' } )
-    newMenu.submenu.push( safeSave(store) )
-    newMenu.submenu.push( safeRead(store) )
+    newMenu.submenu.push( { type: 'separator' } );
+    newMenu.submenu.push( safeSave( store ) );
+    newMenu.submenu.push( safeRead( store ) );
     return newMenu;
-}
+};

--- a/app/extensions/safe/reducers/initialAppState.js
+++ b/app/extensions/safe/reducers/initialAppState.js
@@ -30,7 +30,8 @@ const initialState = {
         experimentsEnabled   : false,
         showingWebIdDropdown : false,
         isFetchingWebIds     : false,
-        webIds               : []
+        webIds               : [],
+        isConnecting         : false
     },
     webFetch : {
         fetching : false,

--- a/app/extensions/safe/reducers/safeBrowserApp.js
+++ b/app/extensions/safe/reducers/safeBrowserApp.js
@@ -106,6 +106,10 @@ export default function safeBrowserApp( state = initialState, action )
             return { ...initialState, isMock: state.isMock };
         }
 
+        case TYPES.SET_IS_CONNECTING:
+        {
+            return { ...state, isConnecting: payload };
+        }
         default:
             return state;
     }

--- a/app/extensions/safe/test/app/onNetworkChange.spec.js
+++ b/app/extensions/safe/test/app/onNetworkChange.spec.js
@@ -55,7 +55,7 @@ describe( 'Network callback', () =>
         expect( dispatchArgOne.payload ).toBe( SAFE.NETWORK_STATE.DISCONNECTED );
 
         expect( dispatchArgTwo.type ).toBe( TYPES.ADD_NOTIFICATION );
-        expect( dispatchArgTwo.payload.text ).toBe( 'Network state: Disconnected. Reconnecting...' );
+        expect( dispatchArgTwo.payload.text ).toBe( 'Network state: Disconnected' );
     } );
 
     it( 'network callback invokes operation to begin reconnection attempts upon Disconnect event', () =>

--- a/app/extensions/safe/test/auth/auth.spec.js
+++ b/app/extensions/safe/test/auth/auth.spec.js
@@ -14,6 +14,8 @@ expect.extend( toBeType );
 
 jest.mock( 'logger' );
 
+jest.setTimeout( 5000 );
+
 let randomCredentials = null;
 const encodedAuthUri = 'safe-auth:bAAAAAAFBMHKYWAAAAAABWAAAAAAAAAAANZSXILTNMFUWI43BM' +
 'ZSS45DFON2C453FMJQXA4BONFSAACYAAAAAAAAAABLWKYSBOBYCAVDFON2A2AAAAAAAAAAAJVQWSZCTMFTG' +

--- a/app/extensions/safe/test/components/wrapNotifer.spec.js
+++ b/app/extensions/safe/test/components/wrapNotifer.spec.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import Notifier from 'components/Notifier';
+import { Button } from 'antd';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+const mockStore = configureStore();
+
+// Some mocks to negate FFI and native libs we dont care about
+jest.mock( 'extensions/safe/ffi/refs/types', () => ( {} ) );
+jest.mock( 'extensions/safe/ffi/refs/constructors', () => ( {} ) );
+jest.mock( 'extensions/safe/ffi/refs/parsers', () => ( {} ) );
+
+jest.mock( 'ref-array', () => jest.fn() );
+//
+jest.mock( 'ffi', () => jest.fn() );
+jest.mock( 'extensions/safe/ffi/authenticator', () => jest.fn() );
+
+jest.mock( '@maidsafe/safe-node-app', () => jest.fn() );
+jest.mock( 'extensions/safe/actions/safeBrowserApplication_actions' );
+
+describe( 'ExtendedNotifier', () =>
+{
+    let wrapper;
+    let props = {};
+    let store;
+
+    beforeEach( () =>
+    {
+        props = {
+            isVisible          : false,
+            type               : 'alert',
+            acceptText         : 'Accept',
+            denyText           : 'Deny',
+            updateNotification : jest.fn(),
+            clearNotification  : jest.fn(),
+            safeBrowserApp     : {
+                isConnecting : false
+            }
+        };
+        store = mockStore( props );
+    } );
+
+    describe( 'handleReconnect', () =>
+    {
+        beforeEach( () =>
+        {
+            props = { ...props, isVisible: true, type: 'error', text: 'Disconnected', handleReconnect: true };
+            wrapper = mount(
+                <Provider store={ store } >
+                    <Notifier { ...props } />
+                </Provider > );
+        } );
+
+        it( 'should have exactly 1 Button component', () =>
+        {
+            expect( wrapper.find( Button ).length ).toBe( 1 );
+            expect( wrapper.find( Button ).text() ).toBe( 'Reconnect' );
+        } );
+    } );
+} );

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -66,7 +66,6 @@ ipcMain.on( 'opn', ( event, data ) =>
     shell.openExternal(data)
 } );
 
-
 let mainWindow = null;
 
 // Do any pre app extension work

--- a/app/reducers/tabs.js
+++ b/app/reducers/tabs.js
@@ -218,10 +218,16 @@ const moveActiveTabForward = ( state, windowId ) =>
 };
 
 
-const moveActiveTabBackwards = ( state, windowId ) =>
+const moveActiveTabBackwards = ( state, payload ) =>
 {
-    const tab = getActiveTab( state, windowId );
-    const index = getActiveTabIndex( state, windowId );
+    const { windowId, index } = payload;
+    let tab = getActiveTab( state, windowId );
+    let tabIndex = getActiveTabIndex( state, windowId );
+    if ( index )
+    {
+        tab = state[index];
+        tabIndex = index;
+    }
     const updatedTab = { ...tab };
     const history = updatedTab.history;
     const nextHistoryIndex = updatedTab.historyIndex - 1;
@@ -240,7 +246,7 @@ const moveActiveTabBackwards = ( state, windowId ) =>
     updatedTab.historyIndex = nextHistoryIndex;
     updatedTab.url = newUrl;
 
-    updatedState[index] = updatedTab;
+    updatedState[tabIndex] = updatedTab;
     return updatedState;
 };
 


### PR DESCRIPTION
Resolves #457 

  - Fixed: Upon network disconnect, automated reconnect attempts are more
    stable
  - Added: Reconnect countdown UI
  - Added: On disconnect notification, user is given button to manually reconnect
  - Added: Test spec for new Notifier extension
  - Changed: Removes close tab/add tab behavior when load fails due to
    network disconnect. Replaced with reload behavior solely when network reconnects.

For QA:
Instead of waiting 2 minutes for network connection to be dropped upon simulating network disconnect, I switch from Ethernet connection to WIFI, which instantaneously triggers a network disconnect in the browser.