### PR TITLE
fix(auth-ui): adds missing padding and fixes grammar

### DIFF
--- a/app/extensions/safe/auth-web-app/sass/auth.scss
+++ b/app/extensions/safe/auth-web-app/sass/auth.scss
@@ -4,8 +4,7 @@
     width: 100%;
     .auth-cont-1 {
       width: 100%;
-      padding-top: 40px;
-      padding-bottom: 20px;
+      padding: 5%;
       font: {
         size: 16px;
         weight: normal;

--- a/app/extensions/safe/locales/en.json
+++ b/app/extensions/safe/locales/en.json
@@ -47,7 +47,7 @@
   },
   "auth_intro": {
     "desc": {
-      "welcome": "Authenticator will act as your gateway to the SAFE Network, you can use it authorise apps to connect on your behalf.",
+      "welcome": "Authenticator will act as your gateway to the SAFE Network, you can use it to authorise apps to act on your behalf.",
       "secret": "Your account secret is private and should not be shared with anyone.",
       "password": "Your account password is never stored or transmitted, it will not leave your computer.",
       "invite_code": "Enter an invitation token or claim an invitation below.",


### PR DESCRIPTION
You may ask why this is necessary.
[This text](https://github.com/maidsafe/safe_browser/blame/b0845742c6a10c2b9bb20bba2acfe069f2a41169/app/extensions/safe/auth-web-app/components/create_account.js#L159) was previously unstyled, simply using `<br>` to format.
It was no longer formatted when moved to `locales/en.json` for `i18n`.