### PR TITLE
fix(Blocked URL Handling): Blocked urls will now only send a tab back…

### DIFF
--- a/__tests__/components/Tab.spec.js
+++ b/__tests__/components/Tab.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { mount, render, shallow } from 'enzyme';
-
 import Tab from 'components/Tab';
 import { CLASSES } from 'appConstants';
 
@@ -13,17 +12,20 @@ describe( 'Tab', () =>
     beforeEach( () =>
     {
         props = {
-            url                     : '',
-            index                   : 1,
-            updateTab               : jest.fn(),
-            closeTab                : jest.fn(),
-            addTab                  : jest.fn(),
-            pageLoaded              : false,
-            isActiveTabReloading    : false,
+            url                  : '',
+            index                : 1,
+            updateTab            : jest.fn(),
+            setActiveTab         : jest.fn(),
+            addNotification      : jest.fn(),
+            activeTabBackwards   : jest.fn(),
+            closeTab             : jest.fn(),
+            addTab               : jest.fn(),
+            pageLoaded           : false,
+            isActiveTabReloading : false,
 
         };
 
-        wrapper = mount( <Tab { ...props } setActiveTab={ jest.fn() } /> );
+        wrapper = mount( <Tab { ...props } /> );
         instance = wrapper.instance();
     } );
 
@@ -61,6 +63,60 @@ describe( 'Tab', () =>
             expect( instance.loadURL.mock.calls.length ).toBe( 0 );
             instance.componentWillReceiveProps( { url: 'helllllllo' } );
             expect( instance.loadURL.mock.calls.length ).toBe( 1 );
+        } );
+    } );
+
+    describe( 'didFailLoad', () =>
+    {
+        beforeEach( () =>
+        {
+            props = {
+                url                  : '',
+                index                : 1,
+                updateTab            : jest.fn(),
+                setActiveTab         : jest.fn(),
+                addNotification      : jest.fn(),
+                activeTabBackwards   : jest.fn(),
+                closeTab             : jest.fn(),
+                addTab               : jest.fn(),
+                pageLoaded           : false,
+                isActiveTabReloading : false,
+
+            };
+
+            wrapper = mount( <Tab { ...props } /> );
+            instance = wrapper.instance();
+        } );
+
+        it( 'should exist', () =>
+        {
+            expect( instance.didFailLoad ).not.toBeUndefined();
+        } );
+
+        it( 'should call addNotification when ERR_BLOCKED_BY_CLIENT and trigger a tabUpdate if no canGoBack', () =>
+        {
+            instance.didFailLoad( { errorDescription: 'ERR_BLOCKED_BY_CLIENT' } );
+            expect( props.addNotification ).toHaveBeenCalled();
+        } );
+
+        it( 'trigger a closeTab if no canGoBack', () =>
+        {
+            instance.didFailLoad( { errorDescription: 'ERR_BLOCKED_BY_CLIENT' } );
+            expect( props.addNotification ).toHaveBeenCalled();
+            expect( props.activeTabBackwards ).not.toHaveBeenCalled();
+            expect( props.closeTab ).toHaveBeenCalled();
+        } );
+
+        it( 'trigger activeTabBackwards() if tab canGoBack', () =>
+        {
+            instance.state = {
+                browserState : { canGoBack: true }
+            };
+
+            instance.didFailLoad( { errorDescription: 'ERR_BLOCKED_BY_CLIENT' } );
+            expect( props.addNotification ).toHaveBeenCalled();
+            expect( props.activeTabBackwards ).toHaveBeenCalled();
+            expect( props.closeTab ).not.toHaveBeenCalled();
         } );
     } );
 } );

--- a/app/components/Tab/Tab.jsx
+++ b/app/components/Tab/Tab.jsx
@@ -315,7 +315,14 @@ export default class Tab extends Component
 
     didFailLoad( err )
     {
-        const { url, index, addTab, closeTab, addNotification, activeTabBackwards } = this.props;
+        const {
+            url,
+            index,
+            addTab,
+            closeTab,
+            addNotification,
+            activeTabBackwards
+        } = this.props;
         const { webview } = this;
         const urlObj = stdUrl.parse( url );
         const renderError = ( header, subHeader ) =>
@@ -368,7 +375,15 @@ export default class Tab extends Component
                 reactNode : Error( { error: { header, subHeader } } )
             };
             addNotification( notification );
-            activeTabBackwards();
+            if( this.state.browserState.canGoBack )
+            {
+
+                activeTabBackwards();
+            }
+            else
+            {
+                closeTab({ index });
+            }
             return;
         }
         closeTab( { index } );
@@ -620,7 +635,7 @@ For updates or to submit ideas and suggestions, visit https://github.com/maidsaf
         const { addTab } = this.props;
         const { url } = e;
         logger.verbose('Tab: NewWindow event triggered for url: ', url)
-        // navigate('url/' + url)
+
         const activateTab = e.disposition == 'foreground-tab';
 
         addTab( { url, isActiveTab: activateTab } );

--- a/app/components/Tab/Tab.jsx
+++ b/app/components/Tab/Tab.jsx
@@ -386,8 +386,6 @@ export default class Tab extends Component
             }
             return;
         }
-        closeTab( { index } );
-        addTab( { url, isActiveTab: true } );
     }
 
     didStopLoading( )


### PR DESCRIPTION
…wards if it's possible to do such a thing.

Adds an if check to Tab.jsx error handling.
Adds tests for this portion of error handling.

fixes #539