### PR TITLE
fix(browserWindow): Resizable on Windows by removing `thickFrame` option

### DIFF
--- a/app/openWindow.js
+++ b/app/openWindow.js
@@ -64,7 +64,6 @@ const openWindow = ( store ) =>
         height            : mainWindowState.height,
         titleBarStyle     : 'hiddenInset',
         icon              : appIcon,
-        thickFrame        : false,
         webPreferences    :
         {
             partition : 'persist:safe-tab'

--- a/app/openWindow.js
+++ b/app/openWindow.js
@@ -57,14 +57,14 @@ const openWindow = ( store ) =>
     const newWindowPosition = getNewWindowPosition( mainWindowState );
     const browserWindowConfig =
     {
-        show              : false,
-        x                 : newWindowPosition.x,
-        y                 : newWindowPosition.y,
-        width             : mainWindowState.width,
-        height            : mainWindowState.height,
-        titleBarStyle     : 'hiddenInset',
-        icon              : appIcon,
-        webPreferences    :
+        show           : false,
+        x              : newWindowPosition.x,
+        y              : newWindowPosition.y,
+        width          : mainWindowState.width,
+        height         : mainWindowState.height,
+        titleBarStyle  : 'hiddenInset',
+        icon           : appIcon,
+        webPreferences :
         {
             partition : 'persist:safe-tab'
             // preload : path.join( __dirname, 'browserPreload.js' )


### PR DESCRIPTION
Resolves #490 