### PR TITLE
fix(auth): proper values returned on auth_decode_ipc_msg errors

### DIFF
--- a/app/extensions/safe/test/auth/auth.spec.js
+++ b/app/extensions/safe/test/auth/auth.spec.js
@@ -21,9 +21,18 @@ const encodedAuthUri = 'safe-auth:bAAAAAAFBMHKYWAAAAAABWAAAAAAAAAAANZSXILTNMFUWI
     + 'AL5YHKYTMNFRQCAAAAAAAAAAAAAAAAAAB';
 /* const encodedUnRegisterAuthUri = 'safe-auth:bAAAAAADKLNT46AQAAAABWAAAAAAAAAAANZSXILT' +
 'NMFUWI43BMZSS45DFON2C453FMJQXA4BONFSAC'; */
-const encodedContUri = 'safe-auth:bAAAAAAHQQQ2XQAIAAAABWAAAAAAAAAAANZSXILTNMFUWI43BM'
-    + 'ZSS45DFON2C453FMJQXA4BONFSAACYAAAAAAAAAABLWKYSBOBYCAVDFON2A2AAAAAAAAAAAJVQWSZCTMFTG'
-    + 'KICMORSC4AIAAAAAAAAAAADQAAAAAAAAAAC7OB2WE3DJMMAQAAAAAAAAAAABAAAAAAI';
+const encodedContUri = 'safe-auth:bAAAAAAHQQQ2XQAIAAAABWAAAAAAAAAAANZSXILTNMFUWI43BM' +
+'ZSS45DFON2C453FMJQXA4BONFSAACYAAAAAAAAAABLWKYSBOBYCAVDFON2A2AAAAAAAAAAAJVQWSZCTMFTG' +
+'KICMORSC4AIAAAAAAAAAAADQAAAAAAAAAAC7OB2WE3DJMMAQAAAAAAAAAAABAAAAAAI';
+
+const encodedNonExistentShareMDataReq = 'safe-auth:bAAAAAAA7BILOYAYAAAACOAAAAAAAAAAANZSXILTNMFUWI43BMZSS4YLQNFPXA3DBPFTXE33VNZSC453FMJRWY2LFNZ2C4OIAC4AAAAAAAAAAAU2BIZCSA53FMIQECUCJEBYGYYLZM5ZG65LOMQGQAAAAAAAAAACNMFUWIU3BMZSSATDUMQXACAAAAAAAAAAATE5AAAAAAAAAAXYWSFBJN6MFV5OY6TCN3SYOIESF3L7TDFYE2IEQC6WHASMCZEUPAEAQAAAAAE';
+
+const authReqWithoutMockBit = 'safe-auth:bAAAAAAEKDQ7DAAAAAAACOAAAAAAAAAAANZSXILTNMFUWI43BMZSS4YLQNFPXA3DBPFTXE33VNZSC453FMJRWY2LFNZ2C4OIAC4AAAAAAAAAAAU2BIZCSA53FMIQECUCJEBYGYYLZM5ZG65LOMQGQAAAAAAAAAACNMFUWIU3BMZSSATDUMQXACAQAAAAAAAAAAADQAAAAAAAAAAC7OB2WE3DJMMCAAAAAAAAAAAAAAAAAAAIAAAAAEAAAAABQAAAABQAAAAAAAAAAAX3QOVRGY2LDJZQW2ZLTAQAAAAAAAAAAAAAAAAAACAAAAABAAAAAAMAAAAAA';
+
+const sixtyFourBitReq = 'safe-auth:AAAAAIdLdL0AAAAAJwAAAAAAAABuZXQubWFpZHNhZmUuYXBpX3BsYXlncm91bmQud2ViY2xpZW50LjkAFwAAAAAAAABTQUZFIHdlYiBBUEkgcGxheWdyb3VuZA0AAAAAAAAATWFpZFNhZmUgTHRkLgECAAAAAAAAAAcAAAAAAAAAX3B1YmxpYwQAAAAAAAAAAAAAAAEAAAACAAAAAwAAAAwAAAAAAAAAX3B1YmxpY05hbWVzBAAAAAAAAAAAAAAAAQAAAAIAAAADAAAA';
+
+const decodedReqForRandomClient = uri => helper.createRandomAccount()
+    .then( () => client.decodeRequest( uri ) );
 
 const decodedReqForRandomClient = uri =>
     helper.createRandomAccount().then( () => client.decodeRequest( uri ) );
@@ -433,6 +442,48 @@ describe( 'Authenticator functions', () =>
                 // TODO: This should be 'message', 'code' to be consistent.
                 expect( e.description ).toBe( 'IPC error: UnknownApp' );
                 expect( e.error_code ).toBe( -204 );
+                await helper.clearAccount();
+            }
+        } );
+
+        it( 'throws error when encoded auth request generated in live environment, however decoding for mock routing', async () =>
+        {
+            try
+            {
+                await decodedReqForRandomClient( authReqWithoutMockBit );
+            }
+            catch ( e )
+            {
+                expect( e.error_code ).toBe( -208 );
+                expect( e.description ).toBe( 'IPC error: IncompatibleMockStatus' );
+                await helper.clearAccount();
+            }
+        } );
+
+        it( 'throws error when decoding share MData request for non-exsistent MData', async () =>
+        {
+            try
+            {
+                await decodedReqForRandomClient( encodedNonExistentShareMDataReq );
+            }
+            catch ( e )
+            {
+                expect( e.error_code ).toBe( -103 );
+                expect( e.description ).toBe( 'Core error: Routing client error -> Requested data not found' );
+                await helper.clearAccount();
+            }
+        } );
+
+        it( 'throws error when decoding 64-bit auth request', async () =>
+        {
+            try
+            {
+                await decodedReqForRandomClient( sixtyFourBitReq );
+            }
+            catch ( e )
+            {
+                expect( e.error_code ).toBe( -1 );
+                expect( e.description ).toBe( 'IPC error: EncodeDecodeError' );
                 await helper.clearAccount();
             }
         } );

--- a/app/extensions/safe/webviewPreload.js
+++ b/app/extensions/safe/webviewPreload.js
@@ -124,12 +124,7 @@ export const setupSafeAPIs = ( passedStore, win = window ) =>
         return app;
     };
 
-    win.safe.fromAuthUri = async (
-        appInfo,
-        authUri,
-        netStateCallback,
-        options
-    ) =>
+    win.safe.fromAuthUri = async ( appInfo, authURI, netStateCallback, options ) =>
     {
         // TODO: Throw warnings for these options.
         const optionsToUse = {
@@ -159,9 +154,12 @@ export const setupSafeAPIs = ( passedStore, win = window ) =>
     win.safe.authorise = async authObj =>
     {
         if ( !authObj || typeof authObj !== 'object' ) throw new Error( 'Auth object is required' );
-        return createRemoteCall( 'authenticateFromUriObject', passedStore )(
-            authObj
-        );
+        let authReqObj = authObj;
+        if ( !authReqObj.id )
+        {
+            authReqObj = { ...authObj, id: Math.floor( Math.random() * ( 2 ** 32 ) ) };
+        }
+        return createRemoteCall( 'authenticateFromUriObject', passedStore )( authReqObj );
     };
 };
 


### PR DESCRIPTION
  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

Resolves #452 
Resolves #454 

@joshuef @bochaco I'm unable to properly test 2 new cases, see [auth.spec](https://github.com/maidsafe/safe_browser/pull/554/files#diff-a003f29f7e2f9aeecfe6e3fbb39e3d2e), because they both output a `-1 ERR_ENCODE_DECODE_ERROR`. I need to think about what I need to do to properly include these tests.
Also, I've decided to simply show an error notification in browser. I don't think there is an easy way to respond to an external app with an error. The errors occur when attempting to decode the auth requests and decoding is needed to be able to then encode a response. I'll continue to think about a solution.

QA:
Easiest way to test this PR would be to:
- Run API playground
- Initialise app
- Pass object to `authorise` operation and run, where the whole func to be executed as auth should look like: 
```
async () => {
  
        const authReqUri = {
          uri: 'safe-auth:bAAAAAAEKDQ7DAAAAAAACOAAAAAAAAAAANZSXILTNMFUWI43BMZSS4YLQNFPXA3DBPFTXE33VNZSC453FMJRWY2LFNZ2C4OIAC4AAAAAAAAAAAU2BIZCSA53FMIQECUCJEBYGYYLZM5ZG65LOMQGQAAAAAAAAAACNMFUWIU3BMZSSATDUMQXACAQAAAAAAAAAAADQAAAAAAAAAAC7OB2WE3DJMMCAAAAAAAAAAAAAAAAAAAIAAAAAEAAAAABQAAAABQAAAAAAAAAAAX3QOVRGY2LDJZQW2ZLTAQAAAAAAAAAAAAAAAAAACAAAAABAAAAAAMAAAAAA'
      };
  
      // Sends autorisation request to authenticator
      try {
        authUri = await safe.authorise(authReqUri);
      } catch (err) {
        return err;
      }
      return `Auth URI returned. Next, back in auth section, pass authUri to loginFromUri.`;
    }
```
- Expect to see an error notification
- Same steps for [encodedNonExistentShareMDataReq](https://github.com/maidsafe/safe_browser/compare/master...hunterlester:454?expand=1#diff-a003f29f7e2f9aeecfe6e3fbb39e3d2eR28)

To QA with external app:
- You could use my repo and [set `forceUseMock` to `false` here](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L58), in order to get a `-208` error.
- To test for error `-103`, uncomment [this block](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L60-L68), then replace [authUri here](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L69), with the `shareMDataReqUri` variable.
