### PR TITLE
Remove activeTab related logic as default behavior

### DIFF
--- a/__tests__/actions/tabs.spec.js
+++ b/__tests__/actions/tabs.spec.js
@@ -37,16 +37,6 @@ describe( 'tab actions', () =>
         expect( actions.closeTab( payload ) ).toEqual( expectedAction );
     } );
 
-    it( 'should create an action to closeActiveTab', () =>
-    {
-        const payload = { url: 'hi' };
-        const expectedAction = {
-            type : actions.TYPES.CLOSE_ACTIVE_TAB,
-            payload
-        };
-        expect( actions.closeActiveTab( payload ) ).toEqual( expectedAction );
-    } );
-
     it( 'should create an action to reopenTab', () =>
     {
         const payload = { url: 'hi' };

--- a/__tests__/actions/tabs.spec.js
+++ b/__tests__/actions/tabs.spec.js
@@ -66,14 +66,4 @@ describe( 'tab actions', () =>
         };
         expect( actions.updateTab( payload ) ).toEqual( expectedAction );
     } );
-
-    it( 'should create an action to updateActiveTab', () =>
-    {
-        const payload = { url: 'hi' };
-        const expectedAction = {
-            type : actions.TYPES.UPDATE_ACTIVE_TAB,
-            payload
-        };
-        expect( actions.updateActiveTab( payload ) ).toEqual( expectedAction );
-    } );
 } );

--- a/__tests__/components/AddressBar.spec.js
+++ b/__tests__/components/AddressBar.spec.js
@@ -38,11 +38,9 @@ describe( 'AddressBar', () =>
             removeBookmark  : jest.fn(),
             tabBackwards    : jest.fn(),
             tabForwards     : jest.fn(),
-            updateActiveTab : jest.fn(),
             onBlur          : jest.fn(),
             onSelect        : jest.fn(),
             onFocus         : jest.fn(),
-            reloadPage      : jest.fn(),
             activeTab       : {
                 isLoading    : false,
                 historyIndex : 1,

--- a/__tests__/components/AddressBar.spec.js
+++ b/__tests__/components/AddressBar.spec.js
@@ -30,20 +30,20 @@ describe( 'AddressBar', () =>
     beforeEach( () =>
     {
         props = {
-            windowId           : 1,
-            address            : 'about:blank',
-            isSelected         : false,
-            isBookmarked       : false,
-            addBookmark        : jest.fn(),
-            removeBookmark     : jest.fn(),
-            activeTabBackwards : jest.fn(),
-            activeTabForwards  : jest.fn(),
-            updateActiveTab    : jest.fn(),
-            onBlur             : jest.fn(),
-            onSelect           : jest.fn(),
-            onFocus            : jest.fn(),
-            reloadPage         : jest.fn(),
-            activeTab          : {
+            windowId        : 1,
+            address         : 'about:blank',
+            isSelected      : false,
+            isBookmarked    : false,
+            addBookmark     : jest.fn(),
+            removeBookmark  : jest.fn(),
+            tabBackwards    : jest.fn(),
+            tabForwards     : jest.fn(),
+            updateActiveTab : jest.fn(),
+            onBlur          : jest.fn(),
+            onSelect        : jest.fn(),
+            onFocus         : jest.fn(),
+            reloadPage      : jest.fn(),
+            activeTab       : {
                 isLoading    : false,
                 historyIndex : 1,
                 history      : [ 'a', 'b' ]

--- a/__tests__/components/AddressBarButtonsLHS.spec.js
+++ b/__tests__/components/AddressBarButtonsLHS.spec.js
@@ -40,11 +40,9 @@ describe( 'AddressBarButtonsLHS', () =>
             removeBookmark  : jest.fn(),
             tabBackwards    : jest.fn(),
             TabForwards     : jest.fn(),
-            updateActiveTab : jest.fn(),
             onBlur          : jest.fn(),
             onSelect        : jest.fn(),
             onFocus         : jest.fn(),
-            reloadPage      : jest.fn(),
             activeTab       : { isLoading: false }
         };
     } );

--- a/__tests__/components/AddressBarButtonsLHS.spec.js
+++ b/__tests__/components/AddressBarButtonsLHS.spec.js
@@ -32,20 +32,20 @@ describe( 'AddressBarButtonsLHS', () =>
     beforeEach( () =>
     {
         props = {
-            windowId           : 1,
-            address            : 'about:blank',
-            isSelected         : false,
-            isBookmarked       : false,
-            addBookmark        : jest.fn(),
-            removeBookmark     : jest.fn(),
-            activeTabBackwards : jest.fn(),
-            activeTabForwards  : jest.fn(),
-            updateActiveTab    : jest.fn(),
-            onBlur             : jest.fn(),
-            onSelect           : jest.fn(),
-            onFocus            : jest.fn(),
-            reloadPage         : jest.fn(),
-            activeTab          : { isLoading: false }
+            windowId        : 1,
+            address         : 'about:blank',
+            isSelected      : false,
+            isBookmarked    : false,
+            addBookmark     : jest.fn(),
+            removeBookmark  : jest.fn(),
+            tabBackwards    : jest.fn(),
+            TabForwards     : jest.fn(),
+            updateActiveTab : jest.fn(),
+            onBlur          : jest.fn(),
+            onSelect        : jest.fn(),
+            onFocus         : jest.fn(),
+            reloadPage      : jest.fn(),
+            activeTab       : { isLoading: false }
         };
     } );
 

--- a/__tests__/components/AddressBarButtonsRHS.spec.js
+++ b/__tests__/components/AddressBarButtonsRHS.spec.js
@@ -31,20 +31,20 @@ describe( 'AddressBarButtonsRHS', () =>
     beforeEach( () =>
     {
         props = {
-            windowId           : 1,
-            address            : 'about:blank',
-            isSelected         : false,
-            isBookmarked       : false,
-            addBookmark        : jest.fn(),
-            removeBookmark     : jest.fn(),
-            activeTabBackwards : jest.fn(),
-            activeTabForwards  : jest.fn(),
-            updateActiveTab    : jest.fn(),
-            onBlur             : jest.fn(),
-            onSelect           : jest.fn(),
-            onFocus            : jest.fn(),
-            reloadPage         : jest.fn(),
-            activeTab          : { isLoading: false }
+            windowId        : 1,
+            address         : 'about:blank',
+            isSelected      : false,
+            isBookmarked    : false,
+            addBookmark     : jest.fn(),
+            removeBookmark  : jest.fn(),
+            tabBackwards    : jest.fn(),
+            tabForwards     : jest.fn(),
+            updateActiveTab : jest.fn(),
+            onBlur          : jest.fn(),
+            onSelect        : jest.fn(),
+            onFocus         : jest.fn(),
+            reloadPage      : jest.fn(),
+            activeTab       : { isLoading: false }
         };
     } );
 

--- a/__tests__/components/AddressBarButtonsRHS.spec.js
+++ b/__tests__/components/AddressBarButtonsRHS.spec.js
@@ -39,11 +39,9 @@ describe( 'AddressBarButtonsRHS', () =>
             removeBookmark  : jest.fn(),
             tabBackwards    : jest.fn(),
             tabForwards     : jest.fn(),
-            updateActiveTab : jest.fn(),
             onBlur          : jest.fn(),
             onSelect        : jest.fn(),
             onFocus         : jest.fn(),
-            reloadPage      : jest.fn(),
             activeTab       : { isLoading: false }
         };
     } );

--- a/__tests__/components/AddressBarInput.spec.js
+++ b/__tests__/components/AddressBarInput.spec.js
@@ -37,11 +37,9 @@ describe( 'AddressBarInput', () =>
             removeBookmark  : jest.fn(),
             tabBackwards    : jest.fn(),
             tabForwards     : jest.fn(),
-            updateActiveTab : jest.fn(),
             onBlur          : jest.fn(),
             onSelect        : jest.fn(),
             onFocus         : jest.fn(),
-            reloadPage      : jest.fn(),
             activeTab       : { isLoading: false }
         };
     } );

--- a/__tests__/components/AddressBarInput.spec.js
+++ b/__tests__/components/AddressBarInput.spec.js
@@ -29,20 +29,20 @@ describe( 'AddressBarInput', () =>
     beforeEach( () =>
     {
         props = {
-            windowId           : 1,
-            address            : 'about:blank',
-            isSelected         : false,
-            isBookmarked       : false,
-            addBookmark        : jest.fn(),
-            removeBookmark     : jest.fn(),
-            activeTabBackwards : jest.fn(),
-            activeTabForwards  : jest.fn(),
-            updateActiveTab    : jest.fn(),
-            onBlur             : jest.fn(),
-            onSelect           : jest.fn(),
-            onFocus            : jest.fn(),
-            reloadPage         : jest.fn(),
-            activeTab          : { isLoading: false }
+            windowId        : 1,
+            address         : 'about:blank',
+            isSelected      : false,
+            isBookmarked    : false,
+            addBookmark     : jest.fn(),
+            removeBookmark  : jest.fn(),
+            tabBackwards    : jest.fn(),
+            tabForwards     : jest.fn(),
+            updateActiveTab : jest.fn(),
+            onBlur          : jest.fn(),
+            onSelect        : jest.fn(),
+            onFocus         : jest.fn(),
+            reloadPage      : jest.fn(),
+            activeTab       : { isLoading: false }
         };
     } );
 

--- a/__tests__/components/AddressBarInput.spec.js
+++ b/__tests__/components/AddressBarInput.spec.js
@@ -40,7 +40,8 @@ describe( 'AddressBarInput', () =>
             onBlur          : jest.fn(),
             onSelect        : jest.fn(),
             onFocus         : jest.fn(),
-            activeTab       : { isLoading: false }
+            activeTab       : { isLoading: false },
+            updateTab       : jest.fn()
         };
     } );
 
@@ -126,18 +127,18 @@ describe( 'AddressBarInput', () =>
             expect( props.onFocus ).toHaveBeenCalled();
         } );
 
-        it( 'check on onKeyPress if updateActiveTab is called', () =>
+        it( 'check on onKeyPress if updateTab is called', () =>
         {
             const input = wrapper.find( 'Input' );
             input.simulate( 'keyPress', { key: 'Enter', keyCode: 13, which: 13 } );
-            expect( props.updateActiveTab ).toHaveBeenCalled();
+            expect( props.updateTab ).toHaveBeenCalled();
         } );
 
-        it( 'check on onKeyPress if updateActiveTab is called with params', () =>
+        it( 'check on onKeyPress if updateTab is called with params', () =>
         {
             const input = wrapper.find( 'Input' );
             input.simulate( 'keyPress', { key: 'Enter', keyCode: 13, which: 13 } );
-            expect( props.updateActiveTab ).toHaveBeenCalledWith( { url: 'about:blank', windowId: 1 } );
+            expect( props.updateTab ).toHaveBeenCalledWith( { url: 'about:blank', windowId: 1 } );
         } );
 
         it( 'check on onChange, if onSelect() is called', () =>

--- a/__tests__/components/Browser.spec.js
+++ b/__tests__/components/Browser.spec.js
@@ -14,6 +14,7 @@ jest.autoMockOff();
 
 // create any initial state needed
 const initialState = {
+    ui                   : {},
     tabs                 : [],
     windowId             : 1,
     addTab               : jest.fn(),

--- a/__tests__/components/Browser.spec.js
+++ b/__tests__/components/Browser.spec.js
@@ -20,7 +20,6 @@ const initialState = {
     updateTab            : jest.fn(),
     closeTab             : jest.fn(),
     setActiveTab         : jest.fn(),
-    closeActiveTab       : jest.fn(),
     reopenTab            : jest.fn(),
     addBookmark          : jest.fn(),
     removeBookmark       : jest.fn(),

--- a/__tests__/components/Browser.spec.js
+++ b/__tests__/components/Browser.spec.js
@@ -14,9 +14,6 @@ jest.autoMockOff();
 
 // create any initial state needed
 const initialState = {
-    ui : {
-        isActiveTabReloading : false
-    },
     tabs                 : [],
     windowId             : 1,
     addTab               : jest.fn(),
@@ -29,8 +26,6 @@ const initialState = {
     removeBookmark       : jest.fn(),
     selectAddressBar     : jest.fn(),
     deselectAddressBar   : jest.fn(),
-    reloadPage           : jest.fn(),
-    pageLoaded           : jest.fn(),
     blurAddressBar       : jest.fn(),
     addNotification      : jest.fn(),
     clearNotification    : jest.fn(),

--- a/__tests__/components/Tab.spec.js
+++ b/__tests__/components/Tab.spec.js
@@ -19,8 +19,6 @@ describe( 'Tab', () =>
             tabBackwards         : jest.fn(),
             closeTab             : jest.fn(),
             addTab               : jest.fn(),
-            pageLoaded           : false,
-            isActiveTabReloading : false
         };
 
         wrapper = mount( <Tab { ...props } /> );
@@ -77,8 +75,6 @@ describe( 'Tab', () =>
                 tabBackwards         : jest.fn(),
                 closeTab             : jest.fn(),
                 addTab               : jest.fn(),
-                pageLoaded           : false,
-                isActiveTabReloading : false
             };
 
             wrapper = mount( <Tab { ...props } /> );

--- a/__tests__/components/Tab.spec.js
+++ b/__tests__/components/Tab.spec.js
@@ -16,7 +16,7 @@ describe( 'Tab', () =>
             updateTab            : jest.fn(),
             setActiveTab         : jest.fn(),
             addNotification      : jest.fn(),
-            activeTabBackwards   : jest.fn(),
+            tabBackwards         : jest.fn(),
             closeTab             : jest.fn(),
             addTab               : jest.fn(),
             pageLoaded           : false,
@@ -74,7 +74,7 @@ describe( 'Tab', () =>
                 updateTab            : jest.fn(),
                 setActiveTab         : jest.fn(),
                 addNotification      : jest.fn(),
-                activeTabBackwards   : jest.fn(),
+                tabBackwards         : jest.fn(),
                 closeTab             : jest.fn(),
                 addTab               : jest.fn(),
                 pageLoaded           : false,
@@ -100,11 +100,11 @@ describe( 'Tab', () =>
         {
             instance.didFailLoad( { errorDescription: 'ERR_BLOCKED_BY_CLIENT' } );
             expect( props.addNotification ).toHaveBeenCalled();
-            expect( props.activeTabBackwards ).not.toHaveBeenCalled();
+            expect( props.tabBackwards ).not.toHaveBeenCalled();
             expect( props.closeTab ).toHaveBeenCalled();
         } );
 
-        it( 'trigger activeTabBackwards() if tab canGoBack', () =>
+        it( 'trigger tabBackwards() if tab canGoBack', () =>
         {
             instance.state = {
                 browserState : { canGoBack: true }
@@ -112,7 +112,7 @@ describe( 'Tab', () =>
 
             instance.didFailLoad( { errorDescription: 'ERR_BLOCKED_BY_CLIENT' } );
             expect( props.addNotification ).toHaveBeenCalled();
-            expect( props.activeTabBackwards ).toHaveBeenCalled();
+            expect( props.tabBackwards ).toHaveBeenCalled();
             expect( props.closeTab ).not.toHaveBeenCalled();
         } );
     } );

--- a/__tests__/reducers/tabs.spec.js
+++ b/__tests__/reducers/tabs.spec.js
@@ -528,19 +528,19 @@ describe( 'tabs reducer', () =>
         } );
     } );
 
-    describe( 'ACTIVE_TAB_FORWARDS', () =>
-    {
-        const activeTab = {
-            ...basicTab,
-            isActiveTab  : true,
-            history      : [ 'hello', 'forward', 'forward again' ],
-            historyIndex : 0
-        };
 
-        it( 'should move the active tab forwards', () =>
+    describe( 'TAB_FORWARDS', () =>
+    {
+        it( 'should move the active tab forwards, if no tab index specified', () =>
         {
-            const firstUpdate = tabs( [ basicTab, basicTab, activeTab ], {
-                type : TYPES.ACTIVE_TAB_FORWARDS
+            const activeTab = {
+                ...basicTab,
+                isActiveTab  : true,
+                history      : ['hello', 'forward', 'forward again'],
+                historyIndex : 0
+            };
+            const firstUpdate = tabs( [basicTab, basicTab, activeTab], {
+                type : TYPES.TAB_FORWARDS
             } );
 
             const updatedTab = firstUpdate[2];
@@ -553,7 +553,7 @@ describe( 'tabs reducer', () =>
             expect( updatedTab ).toHaveProperty( 'history' );
 
             const secondUpdate = tabs( firstUpdate, {
-                type : TYPES.ACTIVE_TAB_FORWARDS
+                type : TYPES.TAB_FORWARDS
             } );
 
             const updatedTabAgain = secondUpdate[2];
@@ -564,7 +564,7 @@ describe( 'tabs reducer', () =>
             } );
 
             const thirdUpdate = tabs( secondUpdate, {
-                type : TYPES.ACTIVE_TAB_FORWARDS
+                type : TYPES.TAB_FORWARDS
             } );
 
             const updatedTabThree = thirdUpdate[2];
@@ -574,9 +574,64 @@ describe( 'tabs reducer', () =>
                 historyIndex : 2
             } );
         } );
+
+        it( 'should move specified tab forwards, according to tab index', () =>
+        {
+            const nonActiveTab = {
+                ...basicTab,
+                isActiveTab  : false,
+                history      : ['hello', 'forward', 'forward again'],
+                historyIndex : 0,
+                index        : 2
+            };
+            const firstUpdate = tabs( [basicTab, basicTab, nonActiveTab], {
+                type    : TYPES.TAB_FORWARDS,
+                payload : { index: 2 }
+            } );
+
+            const updatedTab = firstUpdate[2];
+            expect( updatedTab ).toMatchObject(
+                {
+                    ...nonActiveTab,
+                    url          : 'forward',
+                    historyIndex : 1
+                }
+            );
+
+            expect( updatedTab ).toHaveProperty( 'history' );
+
+            const secondUpdate = tabs( firstUpdate, {
+                type    : TYPES.TAB_FORWARDS,
+                payload : { index: 2 }
+            } );
+
+            const updatedTabAgain = secondUpdate[2];
+            expect( updatedTabAgain ).toMatchObject(
+                {
+                    ...nonActiveTab,
+                    url          : 'forward again',
+                    historyIndex : 2
+                }
+            );
+
+
+            const thirdUpdate = tabs( secondUpdate, {
+                type    : TYPES.TAB_FORWARDS,
+                payload : { index: 2 }
+            } );
+
+            const updatedTabThree = thirdUpdate[2];
+            expect( updatedTabThree ).toMatchObject(
+                {
+                    ...nonActiveTab,
+                    url          : 'forward again',
+                    historyIndex : 2
+                }
+            );
+        } );
     } );
 
-    describe( 'ACTIVE_TAB_BACKWARDS', () =>
+    describe( 'TAB_BACKWARDS', () =>
     {
         const activeTab = {
             ...basicTab,
@@ -586,11 +641,10 @@ describe( 'tabs reducer', () =>
             url          : 'forward again',
             index        : 1
         };
-
-        it( 'should move the active tab backwards in time', () =>
+        it( 'should move the active tab backwards in time, if no tab index specified', () =>
         {
-            const firstUpdate = tabs( [ basicTab, activeTab ], {
-                type : TYPES.ACTIVE_TAB_BACKWARDS
+            const firstUpdate = tabs( [basicTab, activeTab], {
+                type : TYPES.TAB_BACKWARDS
             } );
 
             const updatedTab = firstUpdate[1];
@@ -603,7 +657,7 @@ describe( 'tabs reducer', () =>
             expect( updatedTab ).toHaveProperty( 'history' );
 
             const secondState = tabs( firstUpdate, {
-                type : TYPES.ACTIVE_TAB_BACKWARDS
+                type : TYPES.TAB_BACKWARDS
             } );
 
             const updatedTabAgain = secondState[1];
@@ -614,7 +668,7 @@ describe( 'tabs reducer', () =>
             } );
 
             const thirdState = tabs( secondState, {
-                type : TYPES.ACTIVE_TAB_BACKWARDS
+                type : TYPES.TAB_BACKWARDS
             } );
 
             const updatedTabThree = thirdState[1];
@@ -623,6 +677,61 @@ describe( 'tabs reducer', () =>
                 url          : 'hello',
                 historyIndex : 0
             } );
+        } );
+
+        it( 'should move the specified tab backwards, according to tab index', () =>
+        {
+            const inActiveTab = {
+                ...basicTab,
+                isActiveTab  : false,
+                history      : ['hello', 'second', 'third'],
+                historyIndex : 2,
+                url          : 'forward again',
+                index        : 1
+            };
+            const firstUpdate = tabs( [basicTab, inActiveTab], {
+                type    : TYPES.TAB_BACKWARDS,
+                payload : { index: 1 }
+            } );
+
+            const updatedTab = firstUpdate[1];
+            expect( updatedTab ).toMatchObject(
+                {
+                    ...inActiveTab,
+                    url          : 'second',
+                    historyIndex : 1
+                }
+            );
+
+            expect( updatedTab ).toHaveProperty( 'history' );
+
+            const secondState = tabs( firstUpdate, {
+                type    : TYPES.TAB_BACKWARDS,
+                payload : { index: 1 }
+            } );
+
+            const updatedTabAgain = secondState[1];
+            expect( updatedTabAgain ).toMatchObject(
+                {
+                    ...inActiveTab,
+                    url          : 'hello',
+                    historyIndex : 0
+                }
+            );
+
+            const thirdState = tabs( secondState, {
+                type    : TYPES.TAB_BACKWARDS,
+                payload : { index: 1 }
+            } );
+
+            const updatedTabThree = thirdState[1];
+            expect( updatedTabThree ).toMatchObject(
+                {
+                    ...inActiveTab,
+                    url          : 'hello',
+                    historyIndex : 0
+                }
+            );
         } );
 
         it( 'should decrease the history/index when going backwards and increase going forwards', () =>
@@ -639,7 +748,7 @@ describe( 'tabs reducer', () =>
             } );
 
             const backwardsOnce = tabs( secondState, {
-                type : TYPES.ACTIVE_TAB_BACKWARDS
+                type : TYPES.TAB_BACKWARDS
             } );
 
             const updatedTab = backwardsOnce[1];
@@ -662,7 +771,7 @@ describe( 'tabs reducer', () =>
             expect( updatedTab.history ).toHaveLength( 5 );
 
             const backwardsAgain = tabs( backwardsOnce, {
-                type : TYPES.ACTIVE_TAB_BACKWARDS
+                type : TYPES.TAB_BACKWARDS
             } );
 
             const updatedTabAgain = backwardsAgain[1];
@@ -685,11 +794,11 @@ describe( 'tabs reducer', () =>
             expect( updatedTabAgain.history ).toHaveLength( 5 );
 
             const forwardsNow = tabs( backwardsOnce, {
-                type : TYPES.ACTIVE_TAB_FORWARDS
+                type : TYPES.TAB_FORWARDS
             } );
 
             const forwardsAgin = tabs( forwardsNow, {
-                type : TYPES.ACTIVE_TAB_FORWARDS
+                type : TYPES.TAB_FORWARDS
             } );
 
             const updatedTabForwards = forwardsAgin[1];
@@ -708,6 +817,44 @@ describe( 'tabs reducer', () =>
             } );
             expect( updatedTabForwards.historyIndex ).toBe( 4 );
             expect( updatedTabForwards.history ).toHaveLength( 5 );
+        } );
+
+        it( 'should move the specified tab backwards, according to window', () =>
+        {
+            const windowOne = {
+                ...activeTab,
+                index    : 0,
+                windowId : 1
+            };
+
+            const windowTwo = {
+                ...activeTab,
+                index    : 1,
+                windowId : 2
+            };
+            const firstUpdate = tabs( [windowOne, windowTwo], {
+                type    : TYPES.TAB_BACKWARDS,
+                payload : { index: 0 }
+            } );
+
+            expect( firstUpdate[0] ).toMatchObject(
+                {
+                    ...activeTab,
+                    url          : 'second',
+                    index        : 0,
+                    historyIndex : 1,
+                    windowId     : 1
+                }
+            );
+            expect( firstUpdate[1] ).toMatchObject(
+                {
+                    ...activeTab,
+                    url          : 'forward again',
+                    historyIndex : 2,
+                    windowId     : 2,
+                    index        : 1,
+                }
+            );
         } );
     } );
 
@@ -729,8 +876,8 @@ describe( 'tabs reducer', () =>
 
         it( 'should remove history on forward/backwards/newURL navigations', () =>
         {
-            const firstUpdate = tabs( [ basicTab, basicTab, activeTab ], {
-                type : TYPES.ACTIVE_TAB_FORWARDS
+            const firstUpdate = tabs( [basicTab, basicTab, activeTab], {
+                type : TYPES.TAB_FORWARDS
             } );
 
             const updatedTab = firstUpdate[2];
@@ -744,7 +891,7 @@ describe( 'tabs reducer', () =>
             expect( updatedTab.history ).toHaveLength( 5 );
 
             const secondUpdate = tabs( firstUpdate, {
-                type : TYPES.ACTIVE_TAB_BACKWARDS
+                type : TYPES.TAB_BACKWARDS
             } );
 
             const updatedTabAgain = secondUpdate[2];

--- a/app/actions/tabs_actions.js
+++ b/app/actions/tabs_actions.js
@@ -1,38 +1,38 @@
 import { createActions } from 'redux-actions';
 
 export const TYPES = {
-    ADD_TAB              : 'ADD_TAB',
-    ACTIVE_TAB_FORWARDS  : 'ACTIVE_TAB_FORWARDS',
-    ACTIVE_TAB_BACKWARDS : 'ACTIVE_TAB_BACKWARDS',
-    CLOSE_TAB            : 'CLOSE_TAB',
-    CLOSE_ACTIVE_TAB     : 'CLOSE_ACTIVE_TAB',
-    UPDATE_TAB           : 'UPDATE_TAB',
-    UPDATE_TABS          : 'UPDATE_TABS',
-    UPDATE_ACTIVE_TAB    : 'UPDATE_ACTIVE_TAB',
-    SET_ACTIVE_TAB       : 'SET_ACTIVE_TAB',
-    REOPEN_TAB           : 'REOPEN_TAB'
+    ADD_TAB           : 'ADD_TAB',
+    TAB_FORWARDS      : 'TAB_FORWARDS',
+    TAB_BACKWARDS     : 'TAB_BACKWARDS',
+    CLOSE_TAB         : 'CLOSE_TAB',
+    CLOSE_ACTIVE_TAB  : 'CLOSE_ACTIVE_TAB',
+    UPDATE_TAB        : 'UPDATE_TAB',
+    UPDATE_TABS       : 'UPDATE_TABS',
+    UPDATE_ACTIVE_TAB : 'UPDATE_ACTIVE_TAB',
+    SET_ACTIVE_TAB    : 'SET_ACTIVE_TAB',
+    REOPEN_TAB        : 'REOPEN_TAB'
 };
 
 export const {
-    addTab,
-    setActiveTab,
-    closeTab,
-    closeActiveTab,
-    reopenTab,
-    updateTab,
-    updateTabs,
-    updateActiveTab,
-    activeTabForwards,
-    activeTabBackwards
+    addTab
+    , setActiveTab
+    , closeTab
+    , closeActiveTab
+    , reopenTab
+    , updateTab
+    , updateTabs
+    , updateActiveTab
+    , tabForwards
+    , tabBackwards
 } = createActions(
-    TYPES.ADD_TAB,
-    TYPES.SET_ACTIVE_TAB,
-    TYPES.CLOSE_TAB,
-    TYPES.CLOSE_ACTIVE_TAB,
-    TYPES.REOPEN_TAB,
-    TYPES.UPDATE_TAB,
-    TYPES.UPDATE_TABS,
-    TYPES.UPDATE_ACTIVE_TAB,
-    TYPES.ACTIVE_TAB_FORWARDS,
-    TYPES.ACTIVE_TAB_BACKWARDS
+    TYPES.ADD_TAB
+    , TYPES.SET_ACTIVE_TAB
+    , TYPES.CLOSE_TAB
+    , TYPES.CLOSE_ACTIVE_TAB
+    , TYPES.REOPEN_TAB
+    , TYPES.UPDATE_TAB
+    , TYPES.UPDATE_TABS
+    , TYPES.UPDATE_ACTIVE_TAB
+    , TYPES.TAB_FORWARDS
+    , TYPES.TAB_BACKWARDS
 );

--- a/app/actions/tabs_actions.js
+++ b/app/actions/tabs_actions.js
@@ -5,7 +5,6 @@ export const TYPES = {
     TAB_FORWARDS      : 'TAB_FORWARDS',
     TAB_BACKWARDS     : 'TAB_BACKWARDS',
     CLOSE_TAB         : 'CLOSE_TAB',
-    CLOSE_ACTIVE_TAB  : 'CLOSE_ACTIVE_TAB',
     UPDATE_TAB        : 'UPDATE_TAB',
     UPDATE_TABS       : 'UPDATE_TABS',
     SET_ACTIVE_TAB    : 'SET_ACTIVE_TAB',
@@ -16,7 +15,6 @@ export const {
     addTab
     , setActiveTab
     , closeTab
-    , closeActiveTab
     , reopenTab
     , updateTab
     , updateTabs
@@ -26,7 +24,6 @@ export const {
     TYPES.ADD_TAB
     , TYPES.SET_ACTIVE_TAB
     , TYPES.CLOSE_TAB
-    , TYPES.CLOSE_ACTIVE_TAB
     , TYPES.REOPEN_TAB
     , TYPES.UPDATE_TAB
     , TYPES.UPDATE_TABS

--- a/app/actions/tabs_actions.js
+++ b/app/actions/tabs_actions.js
@@ -8,7 +8,6 @@ export const TYPES = {
     CLOSE_ACTIVE_TAB  : 'CLOSE_ACTIVE_TAB',
     UPDATE_TAB        : 'UPDATE_TAB',
     UPDATE_TABS       : 'UPDATE_TABS',
-    UPDATE_ACTIVE_TAB : 'UPDATE_ACTIVE_TAB',
     SET_ACTIVE_TAB    : 'SET_ACTIVE_TAB',
     REOPEN_TAB        : 'REOPEN_TAB'
 };
@@ -21,7 +20,6 @@ export const {
     , reopenTab
     , updateTab
     , updateTabs
-    , updateActiveTab
     , tabForwards
     , tabBackwards
 } = createActions(
@@ -32,7 +30,6 @@ export const {
     , TYPES.REOPEN_TAB
     , TYPES.UPDATE_TAB
     , TYPES.UPDATE_TABS
-    , TYPES.UPDATE_ACTIVE_TAB
     , TYPES.TAB_FORWARDS
     , TYPES.TAB_BACKWARDS
 );

--- a/app/actions/ui_actions.js
+++ b/app/actions/ui_actions.js
@@ -7,8 +7,6 @@ export const TYPES = {
     DESELECT_ADDRESS_BAR : 'DESELECT_ADDRESS_BAR',
     SELECT_ADDRESS_BAR   : 'SELECT_ADDRESS_BAR',
     RESET_STORE          : 'RESET_STORE',
-    RELOAD_PAGE          : 'RELOAD_PAGE',
-    PAGE_LOADED          : 'PAGE_LOADED',
     FOCUS_WEBVIEW        : 'FOCUS_WEBVIEW'
 };
 
@@ -19,8 +17,6 @@ export const {
     deselectAddressBar,
     selectAddressBar,
     resetStore,
-    reloadPage,
-    pageLoaded,
     focusWebview
 } = createActions(
     TYPES.SHOW_SETTINGS_MENU,
@@ -29,7 +25,5 @@ export const {
     TYPES.DESELECT_ADDRESS_BAR,
     TYPES.SELECT_ADDRESS_BAR,
     TYPES.RESET_STORE,
-    TYPES.RELOAD_PAGE,
-    TYPES.PAGE_LOADED,
     TYPES.FOCUS_WEBVIEW
 );

--- a/app/components/AddressBar/AddressBar.jsx
+++ b/app/components/AddressBar/AddressBar.jsx
@@ -31,13 +31,12 @@ export default class AddressBar extends Component
         onBlur                : PropTypes.func.isRequired,
         onSelect              : PropTypes.func.isRequired,
         onFocus               : PropTypes.func.isRequired,
-        reloadPage            : PropTypes.func.isRequired,
-        updateActiveTab       : PropTypes.func.isRequired,
         tabBackwards          : PropTypes.func.isRequired,
         tabForwards           : PropTypes.func.isRequired,
         showSettingsMenu      : PropTypes.func.isRequired,
         hideSettingsMenu      : PropTypes.func.isRequired,
-        focusWebview          : PropTypes.func.isRequired
+        focusWebview          : PropTypes.func.isRequired,
+        updateTab             : PropTypes.func.isRequired
     }
 
     static defaultProps =
@@ -60,12 +59,13 @@ export default class AddressBar extends Component
         tabForwards( { windowId } );
     }
 
-    handleRefresh = event => {
+    handleRefresh = ( ) =>
+    {
         // TODO: if cmd or so clicked, hard.
         event.stopPropagation();
-        const { reloadPage } = this.props;
-        reloadPage();
-    };
+        const { updateTab, windowId } = this.props;
+        updateTab( { windowId, shouldReload: true } );
+    }
 
     getSettingsMenuItems = () => {
         const { addTab } = this.props;
@@ -122,7 +122,7 @@ export default class AddressBar extends Component
             removeBookmark,
             isBookmarked,
             activeTab,
-            updateActiveTab,
+            updateTab,
             settingsMenuIsVisible,
             showSettingsMenu,
             hideSettingsMenu,
@@ -145,14 +145,14 @@ export default class AddressBar extends Component
                 >
                     <Col>
                         <ButtonsLHS
-                            activeTab={activeTab}
-                            updateActiveTab={updateActiveTab}
-                            handleBack={this.handleBack}
-                            canGoForwards={canGoForwards}
-                            canGoBackwards={canGoBackwards}
-                            handleForward={this.handleForward}
-                            handleRefresh={this.handleRefresh}
-                            {...props}
+                            activeTab={ activeTab }
+                            updateTab={ updateTab }
+                            handleBack={ this.handleBack }
+                            canGoForwards={ canGoForwards }
+                            canGoBackwards={ canGoBackwards }
+                            handleForward={ this.handleForward }
+                            handleRefresh={ this.handleRefresh }
+                            { ...props }
                         />
                     </Col>
                     <Col className={styles.addressBarCol}>

--- a/app/components/AddressBar/AddressBar.jsx
+++ b/app/components/AddressBar/AddressBar.jsx
@@ -14,45 +14,51 @@ import 'antd/lib/col/style';
 
 import styles from './addressBar.css';
 
-export default class AddressBar extends Component {
-    static propTypes = {
-        address: PropTypes.string,
-        isSelected: PropTypes.bool,
-        settingsMenuIsVisible: PropTypes.bool,
-        activeTab: PropTypes.shape({ url: PropTypes.string }),
-        windowId: PropTypes.number.isRequired,
-        isBookmarked: PropTypes.bool.isRequired,
-        addTab: PropTypes.func.isRequired,
-        addBookmark: PropTypes.func.isRequired,
-        removeBookmark: PropTypes.func.isRequired,
-        onBlur: PropTypes.func.isRequired,
-        onSelect: PropTypes.func.isRequired,
-        onFocus: PropTypes.func.isRequired,
-        reloadPage: PropTypes.func.isRequired,
-        updateActiveTab: PropTypes.func.isRequired,
-        activeTabBackwards: PropTypes.func.isRequired,
-        activeTabForwards: PropTypes.func.isRequired,
-        showSettingsMenu: PropTypes.func.isRequired,
-        hideSettingsMenu: PropTypes.func.isRequired,
-        focusWebview: PropTypes.func.isRequired
-    };
 
-    static defaultProps = {
-        address: '',
-        isSelected: false,
-        settingsMenuIsVisible: false,
-        editingUrl: false
-    };
+export default class AddressBar extends Component
+{
+    static propTypes =
+    {
+        address               : PropTypes.string,
+        isSelected            : PropTypes.bool,
+        settingsMenuIsVisible : PropTypes.bool,
+        activeTab             : PropTypes.shape( { url: PropTypes.string } ),
+        windowId              : PropTypes.number.isRequired,
+        isBookmarked          : PropTypes.bool.isRequired,
+        addTab                : PropTypes.func.isRequired,
+        addBookmark           : PropTypes.func.isRequired,
+        removeBookmark        : PropTypes.func.isRequired,
+        onBlur                : PropTypes.func.isRequired,
+        onSelect              : PropTypes.func.isRequired,
+        onFocus               : PropTypes.func.isRequired,
+        reloadPage            : PropTypes.func.isRequired,
+        updateActiveTab       : PropTypes.func.isRequired,
+        tabBackwards          : PropTypes.func.isRequired,
+        tabForwards           : PropTypes.func.isRequired,
+        showSettingsMenu      : PropTypes.func.isRequired,
+        hideSettingsMenu      : PropTypes.func.isRequired,
+        focusWebview          : PropTypes.func.isRequired
+    }
 
-    handleBack = () => {
-        const { activeTabBackwards, windowId } = this.props;
-        activeTabBackwards(windowId);
-    };
+    static defaultProps =
+    {
+        address               : '',
+        isSelected            : false,
+        settingsMenuIsVisible : false,
+        editingUrl            : false
+    }
 
-    handleForward = () => {
-        const { activeTabForwards, windowId } = this.props;
-        activeTabForwards(windowId);
-    };
+    handleBack = ( ) =>
+    {
+        const { tabBackwards, windowId } = this.props;
+        tabBackwards( { windowId } );
+    }
+
+    handleForward = ( ) =>
+    {
+        const { tabForwards, windowId } = this.props;
+        tabForwards( { windowId } );
+    }
 
     handleRefresh = event => {
         // TODO: if cmd or so clicked, hard.

--- a/app/components/AddressBar/Input/Input.jsx
+++ b/app/components/AddressBar/Input/Input.jsx
@@ -17,24 +17,28 @@ import 'antd/lib/input/style';
  * Left hand side buttons for the Address Bar
  * @extends Component
  */
-class AddressBarInput extends Component {
-    static propTypes = {
-        address: PropTypes.string,
-        isSelected: PropTypes.bool,
-        windowId: PropTypes.number.isRequired,
-        onBlur: PropTypes.func.isRequired,
-        onSelect: PropTypes.func.isRequired,
-        onFocus: PropTypes.func.isRequired,
-        updateActiveTab: PropTypes.func.isRequired
-    };
-    static defaultProps = {
-        address: '',
-        isSelected: false,
-        editingUrl: false
-    };
+class AddressBarInput extends Component
+{
+    static propTypes =
+    {
+        address         : PropTypes.string,
+        isSelected      : PropTypes.bool,
+        windowId        : PropTypes.number.isRequired,
+        onBlur          : PropTypes.func.isRequired,
+        onSelect        : PropTypes.func.isRequired,
+        onFocus         : PropTypes.func.isRequired,
+        updateTab : PropTypes.func.isRequired
+    }
+    static defaultProps =
+    {
+        address    : '',
+        isSelected : false,
+        editingUrl : false
+    }
 
-    constructor(props) {
-        super(props);
+    constructor( props )
+    {
+        super( props );
         this.handleChange = ::this.handleChange;
         this.handleKeyPress = ::this.handleKeyPress;
 
@@ -103,7 +107,7 @@ class AddressBarInput extends Component {
 
         const input = event.target.value;
 
-        this.props.updateActiveTab({ url: input, windowId });
+        this.props.updateTab( { url: input, windowId } );
     }
 
     handleClick = () => {

--- a/app/components/Browser/Browser.jsx
+++ b/app/components/Browser/Browser.jsx
@@ -24,8 +24,6 @@ class Browser extends Component
         selectAddressBar   : PropTypes.func.isRequired,
         deselectAddressBar : PropTypes.func.isRequired,
         blurAddressBar     : PropTypes.func.isRequired,
-        reloadPage         : PropTypes.func.isRequired,
-        pageLoaded         : PropTypes.func.isRequired,
         addTab             : PropTypes.func.isRequired,
         closeTab           : PropTypes.func.isRequired,
         closeActiveTab     : PropTypes.func.isRequired,
@@ -77,58 +75,14 @@ class Browser extends Component
             closeTab,
             closeActiveTab,
             reopenTab,
-            clearNotification
+            clearNotification,
+            tabForwards,
+            tabBackwards,
         } = this.props;
         const addressBar = this.address;
 
         const theBrowser = this;
 
-        if ( !ipcRenderer ) return; // avoid for jest/Electron where we're not in renderer process
-
-        ipcRenderer.on( 'command', ( ...args ) =>
-        {
-            const event = args[0];
-            const type = args[1];
-            const { tabContents } = this;
-
-            const activeTab = tabContents.getActiveTab();
-
-            const extraArgs = args.slice( 2 );
-
-            switch ( type )
-            {
-                case 'file:close-active-tab': {
-                    closeActiveTab();
-                    return;
-                }
-                // case 'file:reopen-closed-tab': return pages.reopenLastRemoved()
-                // case 'edit:find':              return navbar.showInpageFind(page)
-                case 'view:reload':
-                    return activeTab.reload();
-                case 'view:hard-reload':
-                    return activeTab.reloadIgnoringCache();
-                // case 'view:zoom-in':           return zoom.zoomIn(page)
-                // case 'view:zoom-out':          return zoom.zoomOut(page)
-                // case 'view:zoom-reset':        return zoom.zoomReset(page)
-                case 'view:toggle-dev-tools':
-                    return activeTab.isDevToolsOpened()
-                        ? activeTab.closeDevTools()
-                        : activeTab.openDevTools();
-                case 'history:back':
-                    return activeTab.goBack();
-                case 'history:forward':
-                    return activeTab.goForward();
-                // case 'window:toggle-safe-mode':  return pages.toggleSafe();
-                // case 'window:disable-web-security':  return pages.toggleWebSecurity();
-                // case 'window:next-tab':        return pages.changeActiveBy(1)
-                // case 'window:prev-tab':        return pages.changeActiveBy(-1)
-                // case 'set-tab':                return pages.changeActiveTo(arg1)
-                // case 'load-pinned-tabs':       return pages.loadPinnedFromDB()
-                // case 'perms:prompt':           return permsPrompt(arg1, arg2, arg3)
-                default:
-                    console.info( 'unhandled command: ', type );
-            }
-        } );
         const body = document.querySelector( 'body' );
         const div = document.createElement( 'div' );
         div.setAttribute( 'class', 'no_display' );
@@ -184,8 +138,6 @@ class Browser extends Component
             selectAddressBar,
             deselectAddressBar,
             blurAddressBar,
-            reloadPage,
-            pageLoaded,
             focusWebview,
 
             // tabs
@@ -193,7 +145,6 @@ class Browser extends Component
             addTab,
             closeTab,
             setActiveTab,
-            updateActiveTab,
             updateTab,
             tabBackwards,
             tabForwards,
@@ -241,7 +192,6 @@ class Browser extends Component
             <div className={ styles.container }>
                 <TabBar
                     key={ 1 }
-                    updateActiveTab={ updateActiveTab }
                     updateTab={ updateTab }
                     setActiveTab={ setActiveTab }
                     selectAddressBar={ selectAddressBar }
@@ -260,14 +210,13 @@ class Browser extends Component
                     addBookmark={ addBookmark }
                     isBookmarked={ isBookmarked }
                     removeBookmark={ removeBookmark }
-                    reloadPage={ reloadPage }
                     hideSettingsMenu={ hideSettingsMenu }
                     showSettingsMenu={ showSettingsMenu }
                     settingsMenuIsVisible={ ui.settingsMenuIsVisible }
                     isSelected={ ui.addressBarIsSelected }
-                    updateActiveTab={ updateActiveTab }
                     tabBackwards={ tabBackwards }
                     tabForwards={ tabForwards }
+                    updateTab={ updateTab }
                     windowId={ windowId }
                     focusWebview={ focusWebview }
                     ref={ c =>
@@ -282,7 +231,6 @@ class Browser extends Component
                     clearNotification={ clearNotification }
                 />
                 <TabContents
-                    isActiveTabReloading={ ui.isActiveTabReloading }
                     tabBackwards={ tabBackwards }
                     focusWebview={ focusWebview }
                     shouldFocusWebview={ ui.shouldFocusWebview }
@@ -290,10 +238,8 @@ class Browser extends Component
                     key={ 4 }
                     addTab={ addTab }
                     addNotification={ addNotification }
-                    updateActiveTab={ updateActiveTab }
                     updateTab={ updateTab }
                     setActiveTab={ setActiveTab }
-                    pageLoaded={ pageLoaded }
                     tabs={ openTabs }
                     allTabs={ tabs }
                     bookmarks={ bookmarks }

--- a/app/components/Browser/Browser.jsx
+++ b/app/components/Browser/Browser.jsx
@@ -190,8 +190,8 @@ class Browser extends Component
             setActiveTab,
             updateActiveTab,
             updateTab,
-            activeTabBackwards,
-            activeTabForwards,
+            tabBackwards,
+            tabForwards,
 
             // notifications
             addNotification,
@@ -261,9 +261,8 @@ class Browser extends Component
                     settingsMenuIsVisible={ ui.settingsMenuIsVisible }
                     isSelected={ ui.addressBarIsSelected }
                     updateActiveTab={ updateActiveTab }
-                    activeTabBackwards={ activeTabBackwards }
-                    activeTabForwards={ activeTabForwards }
-                    activeTab={ activeTab }
+                    tabBackwards={ tabBackwards }
+                    tabForwards={ tabForwards }
                     windowId={ windowId }
                     focusWebview={ focusWebview }
                     ref={ c =>
@@ -279,7 +278,7 @@ class Browser extends Component
                 />
                 <TabContents
                     isActiveTabReloading={ ui.isActiveTabReloading }
-                    activeTabBackwards={ activeTabBackwards }
+                    tabBackwards={ tabBackwards }
                     focusWebview={ focusWebview }
                     shouldFocusWebview={ ui.shouldFocusWebview }
                     closeTab={ closeTab }

--- a/app/components/Browser/Browser.jsx
+++ b/app/components/Browser/Browser.jsx
@@ -26,7 +26,6 @@ class Browser extends Component
         blurAddressBar     : PropTypes.func.isRequired,
         addTab             : PropTypes.func.isRequired,
         closeTab           : PropTypes.func.isRequired,
-        closeActiveTab     : PropTypes.func.isRequired,
         reopenTab          : PropTypes.func.isRequired,
         updateNotification : PropTypes.func.isRequired,
         clearNotification  : PropTypes.func.isRequired,
@@ -73,7 +72,6 @@ class Browser extends Component
         const {
             addTab,
             closeTab,
-            closeActiveTab,
             reopenTab,
             clearNotification,
             tabForwards,

--- a/app/components/Browser/Browser.jsx
+++ b/app/components/Browser/Browser.jsx
@@ -129,6 +129,11 @@ class Browser extends Component
                     console.info( 'unhandled command: ', type );
             }
         } );
+        const body = document.querySelector( 'body' );
+        const div = document.createElement( 'div' );
+        div.setAttribute( 'class', 'no_display' );
+        div.setAttribute( 'id', 'link_revealer' );
+        body.appendChild( div );
     }
 
     shouldComponentUpdate = nextProps =>

--- a/app/components/Tab/Tab.jsx
+++ b/app/components/Tab/Tab.jsx
@@ -338,13 +338,7 @@ export default class Tab extends Component
 
         this.updateBrowserState( { loading: true } );
         updateTab( tabUpdate );
-        const body = document.querySelector( 'body' );
-        const div = document.createElement( 'div' );
-        div.setAttribute( 'class', 'no_display' );
-        div.setAttribute( 'id', 'link_revealer' );
-        body.appendChild( div );
-        window.addEventListener( 'focus', () =>
-        {
+        window.addEventListener( 'focus', () => {
             this.with( ( webview, webContents ) =>
             {
                 webview.focus();

--- a/app/components/Tab/Tab.jsx
+++ b/app/components/Tab/Tab.jsx
@@ -250,7 +250,7 @@ export default class Tab extends Component
 
         if ( !shouldReload && nextProps.shouldReload )
         {
-            logger.info('should reload, should reload');
+            logger.verbose('Should reload URL: ', nextProps.url);
             this.reload();
             const tabUpdate = {
                 index,

--- a/app/components/Tab/Tab.jsx
+++ b/app/components/Tab/Tab.jsx
@@ -38,13 +38,15 @@ export default class Tab extends Component
         addNotification      : PropTypes.func.isRequired,
         focusWebview         : PropTypes.func.isRequired,
         shouldFocusWebview   : PropTypes.bool.isRequired,
-        activeTabBackwards   : PropTypes.func.isRequired
-    };
+        tabBackwards         : PropTypes.func.isRequired
+    }
 
-    static defaultProps = {
+    static defaultProps =
+    {
         isActiveTab : false,
-        url         : 'http://nowhere.com'
-    };
+        url         : 'http://nowhere.com',
+    }
+
 
     constructor( props )
     {
@@ -359,7 +361,7 @@ export default class Tab extends Component
             addTab,
             closeTab,
             addNotification,
-            activeTabBackwards,
+            tabBackwards,
             windowId
         } = this.props;
         const { webview } = this;
@@ -417,13 +419,14 @@ export default class Tab extends Component
                 reactNode : Error( { error: { header, subHeader } } )
             };
             addNotification( notification );
-            if ( this.state.browserState.canGoBack )
+            if( this.state.browserState.canGoBack )
             {
-                activeTabBackwards();
+
+                tabBackwards( { index, windowId } );
             }
             else
             {
-                closeTab( { index } );
+                closeTab({ index });
 
                 // add a fresh tab (should be only if no more tabs present)
                 addTab( { url: 'about:blank', windowId, isActiveTab: true } );

--- a/app/components/Tab/Tab.jsx
+++ b/app/components/Tab/Tab.jsx
@@ -250,6 +250,7 @@ export default class Tab extends Component
 
         if ( !shouldReload && nextProps.shouldReload )
         {
+            logger.info('should reload, should reload');
             this.reload();
             const tabUpdate = {
                 index,

--- a/app/components/TabContents/TabContents.jsx
+++ b/app/components/TabContents/TabContents.jsx
@@ -15,9 +15,6 @@ export default class TabContents extends Component {
         super(props);
         this.allTabComponents = [];
     }
-    getActiveTab() {
-        return this.activeTab;
-    }
 
     render() {
         const {
@@ -27,10 +24,7 @@ export default class TabContents extends Component {
             bookmarks,
             allTabs,
             tabs,
-            updateActiveTab,
             updateTab,
-            isActiveTabReloading,
-            pageLoaded,
             windowId,
             safeExperimentsEnabled,
             focusWebview,
@@ -86,12 +80,9 @@ export default class TabContents extends Component {
                     webId={ tab.webId }
                     url={ tab.url }
                     isActiveTab={ isActiveTab }
-                    isActiveTabReloading={ isActiveTabReloading }
                     addTab={ addTab }
                     closeTab={ closeTab }
                     updateTab={ updateTab }
-                    updateActiveTab={ updateActiveTab }
-                    pageLoaded={ pageLoaded }
                     key={ tab.index }
                     index={ tab.index }
                     windowId={ windowId }
@@ -99,6 +90,8 @@ export default class TabContents extends Component {
                     focusWebview={ focusWebview }
                     shouldFocusWebview={ shouldFocusWebview }
                     tabBackwards={ tabBackwards }
+                    shouldReload={ tab.shouldReload }
+                    shouldToggleDevTools={ tab.shouldToggleDevTools }
                     ref={ ( c ) =>
                     {
                         if ( isActiveTab )

--- a/app/components/TabContents/TabContents.jsx
+++ b/app/components/TabContents/TabContents.jsx
@@ -35,7 +35,7 @@ export default class TabContents extends Component {
             safeExperimentsEnabled,
             focusWebview,
             shouldFocusWebview,
-            activeTabBackwards
+            tabBackwards
         } = this.props;
 
         const tabComponents = tabs.map((tab, i) => {
@@ -81,32 +81,32 @@ export default class TabContents extends Component {
                     }
                 }
 
-                const TheTab = (
-                    <Tab
-                        addNotification={addNotification}
-                        webId={tab.webId}
-                        url={tab.url}
-                        isActiveTab={isActiveTab}
-                        isActiveTabReloading={isActiveTabReloading}
-                        addTab={addTab}
-                        closeTab={closeTab}
-                        updateTab={updateTab}
-                        updateActiveTab={updateActiveTab}
-                        pageLoaded={pageLoaded}
-                        key={tab.index}
-                        index={tab.index}
-                        windowId={windowId}
-                        safeExperimentsEnabled={safeExperimentsEnabled}
-                        focusWebview={focusWebview}
-                        shouldFocusWebview={shouldFocusWebview}
-                        activeTabBackwards={activeTabBackwards}
-                        ref={c => {
-                            if (isActiveTab) {
-                                this.activeTab = c;
-                            }
-                        }}
-                    />
-                );
+                const TheTab = ( <Tab
+                    addNotification={ addNotification }
+                    webId={ tab.webId }
+                    url={ tab.url }
+                    isActiveTab={ isActiveTab }
+                    isActiveTabReloading={ isActiveTabReloading }
+                    addTab={ addTab }
+                    closeTab={ closeTab }
+                    updateTab={ updateTab }
+                    updateActiveTab={ updateActiveTab }
+                    pageLoaded={ pageLoaded }
+                    key={ tab.index }
+                    index={ tab.index }
+                    windowId={ windowId }
+                    safeExperimentsEnabled={ safeExperimentsEnabled }
+                    focusWebview={ focusWebview }
+                    shouldFocusWebview={ shouldFocusWebview }
+                    tabBackwards={ tabBackwards }
+                    ref={ ( c ) =>
+                    {
+                        if ( isActiveTab )
+                        {
+                            this.activeTab = c;
+                        }
+                    } }
+                /> );
                 return TheTab;
             }
         });

--- a/app/extensions/safe/auth-web-app/containers/login.js
+++ b/app/extensions/safe/auth-web-app/containers/login.js
@@ -6,8 +6,7 @@ import Login from '../components/login';
 import {
     login,
     clearAuthLoader,
-    clearError,
-    hideLibErrPopup
+    clearError
 } from '../actions/auth';
 
 const mapStateToProps = state => ( {
@@ -24,8 +23,7 @@ const mapDispatchToProps = dispatch => ( {
         {
             login,
             clearAuthLoader,
-            clearError,
-            hideLibErrPopup
+            clearError
         },
         dispatch
     )

--- a/app/extensions/safe/components/webIdDropdown/WebIdDropdown.js
+++ b/app/extensions/safe/components/webIdDropdown/WebIdDropdown.js
@@ -36,12 +36,12 @@ export default class WebIdDropdown extends Component
         this.debouncedGetWebIds = _.debounce( getAvailableWebIds, 2000 );
     }
 
-    handleIdClick = webId =>
+    handleIdClick = ( webId ) =>
     {
-        const { updateActiveTab, windowId, showWebIdDropdown } = this.props;
+        const { updateTab, windowId, showWebIdDropdown } = this.props;
         // also if only 1 webID? mark as defualt?
-        updateActiveTab( { windowId, webId } );
-    };
+        updateTab( { windowId, webId } );
+    }
 
     handleIdButtonClick = () =>
     {

--- a/app/menu.js
+++ b/app/menu.js
@@ -8,7 +8,8 @@ import {
     tabBackwards,
     closeActiveTab,
     reopenTab,
-    setActiveTab
+    setActiveTab,
+    updateTab
 } from '@Actions/tabs_actions';
 
 import { selectAddressBar } from '@Actions/ui_actions';
@@ -322,41 +323,33 @@ export default class MenuBuilder
                     }
                 },
                 { type: 'separator' },
-                {
-                    label       : 'Reload',
+                { label       : 'Reload',
                     accelerator : 'CommandOrControl+R',
                     click       : ( item, win ) =>
                     {
-                        if ( win ) win.webContents.send( 'command', 'view:reload' );
-                    }
-                },
-                {
-                    label       : 'Toggle Full Screen',
-                    accelerator :
-                        process.platform === 'darwin'
-                            ? 'CommandOrControl+Shift+F'
-                            : 'F11',
-                    click : () =>
+                        if ( win )
+                        {
+                            const windowId = win.webContents.id;
+                            store.dispatch( updateTab( { windowId, shouldReload: true } ) );
+                        }
+;
+                    } },
+                { label       : 'Toggle Full Screen',
+                    accelerator :  process.platform === 'darwin' ? 'CommandOrControl+Shift+F' : 'F11',
+                    click       : () =>
                     {
-                        this.mainWindow.setFullScreen(
-                            !this.mainWindow.isFullScreen()
-                        );
-                    }
-                },
-                {
-                    label       : 'Toggle Developer Tools',
+                        this.mainWindow.setFullScreen( !this.mainWindow.isFullScreen() );
+                    } },
+                { label       : 'Toggle Developer Tools',
                     accelerator : 'Alt+CommandOrControl+I',
                     click       : ( item, win ) =>
                     {
                         if ( win )
                         {
-                            win.webContents.send(
-                                'command',
-                                'view:toggle-dev-tools'
-                            );
+                            const windowId = win.webContents.id;
+                            store.dispatch( updateTab( { windowId, shouldToggleDevTools: true } ) );
                         }
-                    }
-                }
+                    } }
             ]
         };
         const subMenuHistory = {

--- a/app/menu.js
+++ b/app/menu.js
@@ -4,8 +4,8 @@ import {
 } from 'electron';
 import {
     addTab,
-    activeTabForwards,
-    activeTabBackwards,
+    tabForwards,
+    tabBackwards,
     closeActiveTab,
     reopenTab,
     setActiveTab
@@ -391,8 +391,7 @@ export default class MenuBuilder
                     {
                         if ( win )
                         {
-                            // todo check window id
-                            store.dispatch( activeTabForwards() );
+                            store.dispatch( tabForwards() );
                         }
                     }
                 },
@@ -403,8 +402,7 @@ export default class MenuBuilder
                     {
                         if ( win )
                         {
-                            // todo check window id
-                            store.dispatch( activeTabBackwards() );
+                            store.dispatch( tabBackwards() );
                         }
                     }
                 }

--- a/app/menu.js
+++ b/app/menu.js
@@ -6,7 +6,7 @@ import {
     addTab,
     tabForwards,
     tabBackwards,
-    closeActiveTab,
+    closeTab,
     reopenTab,
     setActiveTab,
     updateTab
@@ -219,7 +219,7 @@ export default class MenuBuilder
                             }
                             else
                             {
-                                this.store.dispatch( closeActiveTab( windowId ) );
+                                this.store.dispatch( closeTab( { windowId } ) );
                             }
                         }
                     }
@@ -330,9 +330,8 @@ export default class MenuBuilder
                         if ( win )
                         {
                             const windowId = win.webContents.id;
-                            store.dispatch( updateTab( { windowId, shouldReload: true } ) );
+                            this.store.dispatch( updateTab( { windowId, shouldReload: true } ) );
                         }
-;
                     } },
                 { label       : 'Toggle Full Screen',
                     accelerator :  process.platform === 'darwin' ? 'CommandOrControl+Shift+F' : 'F11',

--- a/app/reducers/initialAppState.js
+++ b/app/reducers/initialAppState.js
@@ -17,7 +17,6 @@ const initialState = {
         settingsMenuIsVisible : false,
         addressBarIsSelected  : false,
         pageIsLoading         : false,
-        isActiveTabReloading  : false,
         shouldFocusWebview    : false
     }
 };

--- a/app/reducers/tabs.js
+++ b/app/reducers/tabs.js
@@ -113,15 +113,21 @@ const addTab = ( state, tab ) =>
  */
 const closeTab = ( state, payload ) =>
 {
-    const index = payload.index;
+    if ( payload && payload.index || payload.index === 0 )
+    {
+        var { index } = payload;
+        var tabToMerge = { ...state[index] };
+    }
+    else
+    {
+        const windowId = payload && payload.windowId ? payload.windowId : undefined;
+        const tab = getActiveTab( state, windowId );
+        var index = getActiveTabIndex( state, windowId );
+        var tabToMerge = { ...tab };
+    }
     const currentWindowId = getCurrentWindowId();
-    const tabToMerge = state[index];
-    const targetWindowId = tabToMerge
-        ? tabToMerge.windowId || currentWindowId
-        : currentWindowId;
-    const openTabs = state.filter(
-        tab => !tab.isClosed && tab.windowId === targetWindowId
-    );
+    const targetWindowId = tabToMerge.windowId ? tabToMerge.windowId : currentWindowId;
+    const openTabs = state.filter( tab => !tab.isClosed && tab.windowId === targetWindowId );
 
     const updatedTab = {
         ...tabToMerge,
@@ -136,7 +142,7 @@ const closeTab = ( state, payload ) =>
 
     if ( tabToMerge.isActiveTab )
     {
-        const ourTabIndex = openTabs.findIndex( tab => tab === tabToMerge );
+        const ourTabIndex = openTabs.findIndex( tab => JSON.stringify( tab ) === JSON.stringify( tabToMerge ) );
 
         const nextTab = ourTabIndex + 1;
         const prevTab = ourTabIndex - 1;
@@ -154,13 +160,6 @@ const closeTab = ( state, payload ) =>
     }
 
     return updatedState;
-};
-
-const closeActiveTab = ( state, windowId ) =>
-{
-    const activeTabIndex = getActiveTabIndex( state, windowId );
-
-    return closeTab( state, { index: activeTabIndex } );
 };
 
 const deactivateOldActiveTab = ( state, windowId ) =>
@@ -423,10 +422,8 @@ export default function tabs( state: array = initialState, action )
         case TYPES.CLOSE_TAB: {
             return closeTab( state, payload );
         }
-        case TYPES.CLOSE_ACTIVE_TAB: {
-            return closeActiveTab( state, payload );
-        }
-        case TYPES.REOPEN_TAB: {
+        case TYPES.REOPEN_TAB :
+        {
             return reopenTab( state );
         }
         case TYPES.UPDATE_TAB :

--- a/app/reducers/tabs.js
+++ b/app/reducers/tabs.js
@@ -212,10 +212,10 @@ export function getLastClosedTab( state )
 
 const moveTabForwards = ( state, payload ) =>
 {
-    if ( payload && payload.index )
+    if ( payload && payload.index || payload.index === 0 )
     {
         var { index } = payload;
-        var updatedTab = state[index];
+        var updatedTab = { ...state[index] };
     }
     else
     {
@@ -248,10 +248,10 @@ const moveTabForwards = ( state, payload ) =>
 
 const moveTabBackwards = ( state, payload ) =>
 {
-    if ( payload && payload.index )
+    if ( payload && payload.index || payload.index === 0)
     {
         var { index } = payload;
-        var updatedTab = state[index];
+        var updatedTab = { ...state[index] };
     }
     else
     {
@@ -360,58 +360,31 @@ const updateTabHistory = ( tabToMerge, payload ) =>
     return updatedTab;
 };
 
-const updateActiveTab = ( state, payload ) =>
-{
-    const { windowId } = payload;
-
-    const index = state.findIndex(
-        tab => tab.isActiveTab && tab.windowId === windowId
-    );
-
-    if ( !windowId )
-    {
-        throw new Error(
-            'Updating Active Tab requires the relevant windowId to be passed.'
-        );
-    }
-
-    if ( index < 0 ) return state;
-
-    const tabToMerge = state[index];
-
-    let updatedTab = { ...tabToMerge };
-
-    updatedTab = { ...updatedTab, ...payload };
-
-    if ( payload.url )
-    {
-        updatedTab = updateTabHistory( tabToMerge, payload );
-    }
-
-    const updatedState = [ ...state ];
-
-    updatedState[index] = updatedTab;
-    return updatedState;
-};
-
 const updateTab = ( state, payload ) =>
 {
-    const index = payload.index;
-
-    if ( index < 0 )
+    if ( payload && payload.index || payload.index === 0 )
     {
-        return state;
+        var { index } = payload;
+        if ( index < 0 )
+        {
+            return state;
+        }
+        var updatedTab = { ...state[index] };
+    }
+    else
+    {
+        const windowId = payload && payload.windowId ? payload.windowId : undefined;
+        const tab = getActiveTab( state, windowId );
+        var index = getActiveTabIndex( state, windowId );
+        var updatedTab = { ...tab };
     }
 
-    const tabToMerge = state[index];
-
-    let updatedTab = { ...tabToMerge };
     updatedTab = { ...updatedTab, ...payload };
 
     if ( payload.url )
     {
         const url = makeValidAddressBarUrl( payload.url );
-        updatedTab = updateTabHistory( tabToMerge, payload );
+        updatedTab = updateTabHistory( updatedTab, payload );
     }
 
     const updatedState = [ ...state ];
@@ -456,10 +429,8 @@ export default function tabs( state: array = initialState, action )
         case TYPES.REOPEN_TAB: {
             return reopenTab( state );
         }
-        case TYPES.UPDATE_ACTIVE_TAB: {
-            return updateActiveTab( state, payload );
-        }
-        case TYPES.UPDATE_TAB: {
+        case TYPES.UPDATE_TAB :
+        {
             return updateTab( state, payload );
         }
         case TYPES.TAB_FORWARDS :

--- a/app/reducers/tabs.js
+++ b/app/reducers/tabs.js
@@ -209,14 +209,23 @@ export function getLastClosedTab( state )
     return tabAndIndex;
 }
 
-const moveActiveTabForward = ( state, windowId ) =>
+
+const moveTabForwards = ( state, payload ) =>
 {
-    const tab = getActiveTab( state, windowId );
-    const index = getActiveTabIndex( state, windowId );
-    const updatedTab = { ...tab };
+    if ( payload && payload.index )
+    {
+        var { index } = payload;
+        var updatedTab = state[index];
+    }
+    else
+    {
+        const windowId = payload && payload.windowId ? payload.windowId : undefined;
+        const tab = getActiveTab( state, windowId );
+        var index = getActiveTabIndex( state, windowId );
+        var updatedTab = { ...tab };
+    }
 
     const history = updatedTab.history;
-
     const nextHistoryIndex = updatedTab.historyIndex + 1 || 1;
 
     // -1 historyIndex signifies latest page
@@ -236,11 +245,22 @@ const moveActiveTabForward = ( state, windowId ) =>
     return updatedState;
 };
 
-const moveActiveTabBackwards = ( state, windowId ) =>
+
+const moveTabBackwards = ( state, payload ) =>
 {
-    const tab = getActiveTab( state, windowId );
-    const index = getActiveTabIndex( state, windowId );
-    const updatedTab = { ...tab };
+    if ( payload && payload.index )
+    {
+        var { index } = payload;
+        var updatedTab = state[index];
+    }
+    else
+    {
+        const windowId = payload && payload.windowId ? payload.windowId : undefined;
+        const tab = getActiveTab( state, windowId );
+        var index = getActiveTabIndex( state, windowId );
+        var updatedTab = { ...tab };
+    }
+
     const history = updatedTab.history;
     const nextHistoryIndex = updatedTab.historyIndex - 1;
 
@@ -442,11 +462,13 @@ export default function tabs( state: array = initialState, action )
         case TYPES.UPDATE_TAB: {
             return updateTab( state, payload );
         }
-        case TYPES.ACTIVE_TAB_FORWARDS: {
-            return moveActiveTabForward( state, payload );
+        case TYPES.TAB_FORWARDS :
+        {
+            return moveTabForwards( state, payload );
         }
-        case TYPES.ACTIVE_TAB_BACKWARDS: {
-            return moveActiveTabBackwards( state, payload );
+        case TYPES.TAB_BACKWARDS :
+        {
+            return moveTabBackwards( state, payload );
         }
         case TYPES.UPDATE_TABS: {
             const payloadTabs = payload.tabs;

--- a/app/reducers/ui.js
+++ b/app/reducers/ui.js
@@ -11,28 +11,28 @@ export default function ui( state: array = initialState, action )
 
     switch ( action.type )
     {
-        case TYPES.SHOW_SETTINGS_MENU: {
-            return { ...state, settingsMenuIsVisible: true };
+        case TYPES.SHOW_SETTINGS_MENU :
+        {
+            return { ...state, settingsMenuIsVisible : true };
         }
-        case TYPES.HIDE_SETTINGS_MENU: {
-            return { ...state, settingsMenuIsVisible: false };
+        case TYPES.HIDE_SETTINGS_MENU :
+        {
+            return { ...state, settingsMenuIsVisible : false };
         }
-        case TYPES.SELECT_ADDRESS_BAR: {
-            return { ...state, addressBarIsSelected: true };
+        case TYPES.SELECT_ADDRESS_BAR :
+        {
+            return { ...state, addressBarIsSelected : true };
         }
-        case TYPES.DESELECT_ADDRESS_BAR: {
-            return { ...state, addressBarIsSelected: false };
+        case TYPES.DESELECT_ADDRESS_BAR :
+        {
+            return { ...state, addressBarIsSelected : false };
         }
-        case TYPES.BLUR_ADDRESS_BAR: {
-            return { ...state, addressBarIsSelected: false };
+        case TYPES.BLUR_ADDRESS_BAR :
+        {
+            return { ...state, addressBarIsSelected : false };
         }
-        case TYPES.RELOAD_PAGE: {
-            return { ...state, isActiveTabReloading: true };
-        }
-        case TYPES.PAGE_LOADED: {
-            return { ...state, isActiveTabReloading: false };
-        }
-        case TYPES.FOCUS_WEBVIEW: {
+        case TYPES.FOCUS_WEBVIEW :
+        {
             return { ...state, shouldFocusWebview: payload };
         }
 


### PR DESCRIPTION
Closes #567 

Resolves #522 

QA: 
- Cycling through other tabs while other tab(s) are loading shouldn't interrupt/delay loading
- Big refactor, so this PR should be on regression watch.
