### PR TITLE
Show_menu restricted to Current Window only

### DIFF
--- a/__tests__/actions/ui.spec.js
+++ b/__tests__/actions/ui.spec.js
@@ -10,7 +10,11 @@ describe( 'ui actions', () =>
     it( 'should show settings menu', () =>
     {
         const expectedAction = {
-            type : ui.TYPES.SHOW_SETTINGS_MENU
+            type : ui.TYPES.SHOW_SETTINGS_MENU,
+            meta :
+            {
+                scope : 'local'
+            }
         };
         expect( ui.showSettingsMenu() ).toEqual( expectedAction );
     } );
@@ -18,7 +22,11 @@ describe( 'ui actions', () =>
     it( 'should hide settings menu', () =>
     {
         const expectedAction = {
-            type : ui.TYPES.HIDE_SETTINGS_MENU
+            type : ui.TYPES.HIDE_SETTINGS_MENU,
+            meta :
+            {
+                scope : 'local'
+            }
         };
         expect( ui.hideSettingsMenu() ).toEqual( expectedAction );
     } );
@@ -26,7 +34,11 @@ describe( 'ui actions', () =>
     it( 'should set addressbar selected', () =>
     {
         const expectedAction = {
-            type : ui.TYPES.SELECT_ADDRESS_BAR
+            type : ui.TYPES.SELECT_ADDRESS_BAR,
+            meta :
+            {
+                scope : 'local'
+            }
         };
         expect( ui.selectAddressBar() ).toEqual( expectedAction );
     } );
@@ -34,7 +46,11 @@ describe( 'ui actions', () =>
     it( 'should set addressbar deselected', () =>
     {
         const expectedAction = {
-            type : ui.TYPES.DESELECT_ADDRESS_BAR
+            type : ui.TYPES.DESELECT_ADDRESS_BAR,
+            meta :
+            {
+                scope : 'local'
+            }
         };
         expect( ui.deselectAddressBar() ).toEqual( expectedAction );
     } );
@@ -42,7 +58,11 @@ describe( 'ui actions', () =>
     it( 'should clear a notification', () =>
     {
         const expectedAction = {
-            type : ui.TYPES.BLUR_ADDRESS_BAR
+            type : ui.TYPES.BLUR_ADDRESS_BAR,
+            meta :
+            {
+                scope : 'local'
+            }
         };
         expect( ui.blurAddressBar() ).toEqual( expectedAction );
     } );
@@ -50,7 +70,11 @@ describe( 'ui actions', () =>
     it( 'should resetStore', () =>
     {
         const expectedAction = {
-            type : ui.TYPES.RESET_STORE
+            type : ui.TYPES.RESET_STORE,
+            meta :
+            {
+                scope : 'local'
+            }
         };
         expect( ui.resetStore() ).toEqual( expectedAction );
     } );

--- a/app/actions/ui_actions.js
+++ b/app/actions/ui_actions.js
@@ -23,13 +23,42 @@ export const {
     pageLoaded,
     focusWebview
 } = createActions(
-    TYPES.SHOW_SETTINGS_MENU,
-    TYPES.HIDE_SETTINGS_MENU,
-    TYPES.BLUR_ADDRESS_BAR,
-    TYPES.DESELECT_ADDRESS_BAR,
-    TYPES.SELECT_ADDRESS_BAR,
-    TYPES.RESET_STORE,
-    TYPES.RELOAD_PAGE,
-    TYPES.PAGE_LOADED,
-    TYPES.FOCUS_WEBVIEW
+    {
+        SHOW_SETTINGS_MENU : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ],
+        HIDE_SETTINGS_MENU : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ],
+        BLUR_ADDRESS_BAR : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ],
+        DESELECT_ADDRESS_BAR : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ],
+        SELECT_ADDRESS_BAR : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ],
+        RESET_STORE : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ],
+        RELOAD_PAGE : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ],
+        PAGE_LOADED : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ],
+        FOCUS_WEBVIEW : [
+            undefined,
+            () => ( { scope: 'local' } ) // meta
+        ]
+    }
 );

--- a/app/components/AddressBar/AddressBar.jsx
+++ b/app/components/AddressBar/AddressBar.jsx
@@ -63,9 +63,9 @@ export default class AddressBar extends Component {
 
     getSettingsMenuItems = () => {
         const { addTab } = this.props;
-
+        const { windowId } = this.props;
         const addATab = tab => {
-            addTab({ url: `safe-browser://${tab}`, isActiveTab: true });
+            addTab( { url: `safe-browser://${tab}`, isActiveTab: true, windowId } );
         };
 
         return [

--- a/app/extensions/safe/test/e2e/safe-bookmark-login-out.network.spec.js
+++ b/app/extensions/safe/test/e2e/safe-bookmark-login-out.network.spec.js
@@ -134,9 +134,9 @@ describe( 'SAFE network log in and out', async () =>
 
             await delay( 8000 );
             // await delay( 1500 );
-            const bookmarks = await client.getText( '.urlList__table' );
+            const bookmarks = await client.getText( '.urlList__table .tableRow__default .tableCell__default a' );
             // bookmarks is an array
-            expect( bookmarks ).toMatch( 'shouldsavetobookmarks' );
+            expect( bookmarks ).toContain( 'safe://shouldsavetobookmarks.com' );
             await delay( 1500 );
         } );
 
@@ -242,7 +242,7 @@ describe( 'SAFE network log in and out', async () =>
             const bookmarksFinalCheck = await client.getText( '.urlList__table' );
 
             // bookmarksFinalCheck is an array
-            expect( bookmarksFinalCheck ).not.toMatch( 'shouldsavetobookmarks' );
+            expect( bookmarksFinalCheck ).not.toContain( 'shouldsavetobookmarks' );
         } );
     } );
 } );


### PR DESCRIPTION

Resolves #562 

Steps to test the resolution.
For example:
```
QA:
The easiest way to test this PR would be to:
-Open a new window
-If upon showing the menu, it doesn't show the menu in all windows of the browser
-If upon reloading the active tab in one window, does not cause the active tabs in other windows to reload as well
-If upon opening history or bookmarks in one window, does not open history and bookmarks in other windows of the browser as well
```
