### PR TITLE
fix top padding based on OS specification

### DIFF
--- a/app/components/TabBar/TabBar.jsx
+++ b/app/components/TabBar/TabBar.jsx
@@ -1,7 +1,8 @@
-// @flow
+/* eslint-disable */
 import { remote } from 'electron';
 import url from 'url';
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import styles from './tabBar.css';
 import MdClose from 'react-icons/lib/md/close';
@@ -144,10 +145,9 @@ export default class TabBar extends Component {
             );
         });
     };
-
     render() {
         return (
-            <div className={styles.container}>
+            <div className= {[styles.container , (process.platform === 'darwin' ? styles.containerMac : "") ].join(' ')}>
                 <div className={styles.tabBar}>
                     {this.getTabs()}
                     <div

--- a/app/components/TabBar/tabBar.css
+++ b/app/components/TabBar/tabBar.css
@@ -3,13 +3,21 @@
 {
     flex: 0;
     height: 100%;
-    padding-left:     10px;
-    padding-right:     10px;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 5px;
     background: rgba( 207, 208, 209, 1);
     z-index: 4;
     font-size: 1.4rem;
     -webkit-app-region: drag;
 }
+
+.containerMac
+{
+    padding-top: 10px;
+    padding-left: 100px;
+}
+
 
 
 .tabBar

--- a/app/constants.js
+++ b/app/constants.js
@@ -4,7 +4,7 @@ import { remote } from 'electron';
 import pkg from '@Package';
 import getPort from 'get-port';
 
-const platform = process.platform;
+export const platform = process.platform;
 const OSX = 'darwin';
 const LINUX = 'linux';
 const WINDOWS = 'win32';


### PR DESCRIPTION

Resolves #586 
```
QA:
The easiest way to test this PR would be to:
-Initialize the browser on Mac OS
-And check if close/minimize icons do not overlap any UI.
(Similarly for windows)
```