### PR TITLE
fix packaging issue on windows

### DIFF
--- a/post-pack.js
+++ b/post-pack.js
@@ -93,7 +93,6 @@ if ( platform === WINDOWS )
         path.resolve( CONTAINING_FOLDER, 'SAFE Browser.crust.config' ),
         { overwrite: true }
     );
-    fs.unlinkSync( path.resolve( CONTAINING_FOLDER, 'safe-browser.crust.config' ) );
     fs.unlinkSync(
         path.resolve( PERUSE_RESOURCES_FOLDER, 'SAFE Browser.crust.config' )
     );


### PR DESCRIPTION
Remove unnecessary unlinkSync, which was occuring during post-pack