### PR TITLE
chore(deps): use open instead of shell.openExternal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_script:
 
 script:
 # update the xdg implementation on the machine. older version is buggy
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cp node_modules/opn/xdg-open ~/bin/;
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cp node_modules/open/xdg-open ~/bin/;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xdg-open --version;
     fi

--- a/app/extensions/safe/blockNonSafeReqs.ts
+++ b/app/extensions/safe/blockNonSafeReqs.ts
@@ -1,3 +1,4 @@
+import open from 'open';
 import { remote, shell } from 'electron';
 import { parse as parseURL } from 'url';
 import path from 'path';
@@ -43,7 +44,7 @@ const blockNonSAFERequests = () => {
         if ( httpRegExp.test( details.url ) ) {
             if ( allowedHttp.includes( details.url ) ) {
                 try {
-                    shell.openExternal( details.url );
+                    open( details.url );
                 } catch ( e ) {
                     logger.error( e );
                 }

--- a/app/extensions/safe/ffi/ipc.ts
+++ b/app/extensions/safe/ffi/ipc.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+import open from 'open';
 import { shell } from 'electron';
 import { receivedAuthResponse } from '$Extensions/safe/actions/safeBrowserApplication_actions';
 import {
@@ -96,7 +97,7 @@ class ReqQueue {
             return;
         }
         try {
-            shell.openExternal( parseResUrl( uri ) );
+            open( parseResUrl( uri ) );
         } catch ( err ) {
             logger.error( err.message );
         }

--- a/app/extensions/safe/safeBrowserApplication/init/initAuthed.ts
+++ b/app/extensions/safe/safeBrowserApplication/init/initAuthed.ts
@@ -38,7 +38,7 @@ const initAuthedApplication = async ( passedStore, options ) => {
         global.browserAuthReqUri = authReq.uri;
 
         if ( process.platform === 'win32' ) {
-            ipcRenderer.send( 'opn', authReq.uri );
+            ipcRenderer.send( 'open', authReq.uri );
         } else {
             await safeBrowserAppObject.auth.openUri( authReq.uri );
         }

--- a/app/extensions/safe/test/e2e/safe-auth.spec.ts
+++ b/app/extensions/safe/test/e2e/safe-auth.spec.ts
@@ -1,4 +1,4 @@
-import opn from 'opn';
+import open from 'open';
 
 import {
     delay,
@@ -55,7 +55,7 @@ describe( 'safe authenticator protocol', () => {
             expect.assertions( 2 );
             const { client } = app;
             await delay( 2500 );
-            opn( 'safe-auth://blabla' );
+            open( 'safe-auth://blabla' );
             await delay( 2500 );
 
             setClientToMainBrowserWindow( app );

--- a/app/extensions/safe/test/e2e/safe.spec.ts
+++ b/app/extensions/safe/test/e2e/safe.spec.ts
@@ -164,7 +164,7 @@ Therefore need a node version inline w/electron (8 for e2.x eg.)
     //
     //     it( 'is registered to handle safe:// requests:', async( ) =>
     //     {
-    //         opn('safe://blabla');
+    //         open('safe://blabla');
     //         await delay(4500)
     //
     //         setClientToMainBrowserWindow(app);

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -10,7 +10,7 @@
  * @flow
  */
 
-import opn from 'opn';
+import open from 'open';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -64,9 +64,9 @@ ipcMain.on( 'errorInRenderWindow', ( event, data ) => {
 } );
 
 // Needed for windows w/ SAFE browser app login
-ipcMain.on( 'opn', ( event, data ) => {
-    logger.info( 'Opening link in system via opn.' );
-    shell.openExternal( data );
+ipcMain.on( 'open', ( event, data ) => {
+    logger.info( 'Opening link in system via open.' );
+    open( data );
 } );
 
 let mainWindow = null;

--- a/app/menu.ts
+++ b/app/menu.ts
@@ -1,3 +1,4 @@
+import open from 'open';
 import { app, Menu, shell, BrowserWindow } from 'electron';
 import {
     addTab,
@@ -387,13 +388,13 @@ export default class MenuBuilder {
                 {
                     label: 'Learn More about the Safe Network',
                     click() {
-                        shell.openExternal( 'https://safenetwork.tech/' );
+                        open( 'https://safenetwork.tech/' );
                     }
                 },
                 {
                     label: 'Documentation',
                     click() {
-                        shell.openExternal(
+                        open(
                             'https://github.com/maidsafe/safe_browser/blob/master/README.md'
                         );
                     }
@@ -401,13 +402,13 @@ export default class MenuBuilder {
                 {
                     label: 'Community Discussions',
                     click() {
-                        shell.openExternal( 'https://safenetforum.org' );
+                        open( 'https://safenetforum.org' );
                     }
                 },
                 {
                     label: 'Search Issues',
                     click() {
-                        shell.openExternal(
+                        open(
                             'https://github.com/maidsafe/safe_browser/issues'
                         );
                     }

--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
     "jest-tobetype": "git+https://github.com/joshuef/jest-tobetype.git#master",
     "lodash": ">=4.17.11",
     "nessie-ui": "6.1.0",
-    "opn": "^5.3.0",
+    "open": "^6.1.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-hot-loader": "^4.3.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11994,6 +11994,13 @@ onetime@^2.0.0, onetime@^2.0.1:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-6.1.0.tgz#0e7e671b883976a4e5251b5d1ca905ab6f4be78f"
+  integrity sha512-Vqch7NFb/WsMujhqfq+B3u0xkssRjZlxh+NSsBSphpcgaFD7gfB0SUBfR91E9ygBlyNGNogXR2cUB8rRfoo2kQ==
+  dependencies:
+    is-wsl "^1.1.0"
+
 opencollective-postinstall@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
@@ -12009,7 +12016,7 @@ opensans-npm-webfont@1.0.0:
   resolved "https://registry.yarnpkg.com/opensans-npm-webfont/-/opensans-npm-webfont-1.0.0.tgz#910c8e525887b47eb8a6795846138a0cbac15a47"
   integrity sha512-2ehgrX+NpoxLOil30tYGr0cDsDXSJn9gon6PfM1Ki0CxZF6ui9Mi6Dm5DGglKyK2QiX0gMb6Ch7VmRHwfc4M6Q==
 
-opn@^5.1.0, opn@^5.3.0:
+opn@^5.1.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==


### PR DESCRIPTION
Tracking #570 

`open` is actively maintained, so although this `xdg-utils` [commit](https://cgit.freedesktop.org/xdg/xdg-utils/commit/?id=bfcefa162b1dcd6d62e193019969ff2f5ff331cf) is not yet stable released, it will be and `open` maintainers will be on top of it.