### PR TITLE
chore(linting): Further linting

### DIFF
--- a/__e2e__/lib/browser-driver.ts
+++ b/__e2e__/lib/browser-driver.ts
@@ -4,9 +4,10 @@ import { BROWSER_UI, WAIT_FOR_EXIST_TIMEOUT } from './constants';
 let peruseBrowserWindowIndex;
 let peruseBgWindowIndex;
 
-export const delay = time => new Promise( resolve => setTimeout( resolve, time ) );
+export const delay = ( time ) =>
+    new Promise( ( resolve ) => setTimeout( resolve, time ) );
 
-export const setClientToMainBrowserWindow = async app => {
+export const setClientToMainBrowserWindow = async ( app ) => {
     const { client } = app;
     const windows = await client.getWindowCount();
 
@@ -15,9 +16,11 @@ export const setClientToMainBrowserWindow = async app => {
         return;
     }
 
-    for ( let i = 0; i < windows; i++ ) {
+    for ( let i = 0; i < windows; i += 1 ) {
     // TODO: Use window title to differentiate between PeruseBrowserWindow instances?
+    // eslint-disable-next-line no-await-in-loop
         await client.windowByIndex( i );
+        // eslint-disable-next-line no-await-in-loop
         const url = await client.getUrl();
         const urlObj = urlParse( url );
         // get the PeruseBrowserWindow
@@ -31,12 +34,14 @@ export const setClientToMainBrowserWindow = async app => {
     await client.windowByIndex( peruseBrowserWindowIndex );
 };
 
-export const setClientToBackgroundProcessWindow = async app => {
+export const setClientToBackgroundProcessWindow = async ( app ) => {
     const { client } = app;
     const windows = await client.getWindowCount();
 
-    for ( let i = 0; i < windows; i++ ) {
+    for ( let i = 0; i < windows; i += 1 ) {
+    // eslint-disable-next-line no-await-in-loop
         await client.windowByIndex( i );
+        // eslint-disable-next-line no-await-in-loop
         const url = await client.getUrl();
         const urlObj = urlParse( url );
 
@@ -71,14 +76,16 @@ export const navigateTo = async ( app, url ) => {
     await client.pause( 1500 );
 };
 
-export const newTab = async app => {
+export const newTab = async ( app ) => {
     const { client } = app;
 
     const windows = await client.getWindowCount();
 
-    for ( let i = 0; i < windows; i++ ) {
+    for ( let i = 0; i < windows; i += 1 ) {
     // TODO: Use window title to differentiate between PeruseBrowserWindow instances?
+    // eslint-disable-next-line no-await-in-loop
         await client.windowByIndex( i );
+        // eslint-disable-next-line no-await-in-loop
         await client.getUrl();
     }
 
@@ -90,7 +97,7 @@ export const newTab = async app => {
     return length2 - 1;
 };
 
-export const bookmarkActiveTabPage = async app => {
+export const bookmarkActiveTabPage = async ( app ) => {
     const { client } = app;
     await client.waitForExist( BROWSER_UI.BOOKMARK_PAGE, WAIT_FOR_EXIST_TIMEOUT );
     await client.click( BROWSER_UI.BOOKMARK_PAGE );

--- a/app/definitions/globals.d.ts
+++ b/app/definitions/globals.d.ts
@@ -1,4 +1,5 @@
 import { Store } from 'redux';
+import { BrowserWindow } from 'electron';
 
 declare namespace NodeJS {
     interface Global {
@@ -37,4 +38,11 @@ interface Window {
     safeAuthenticator: {
         isAuthorised: () => boolean;
     };
+}
+
+export interface AppWindow extends BrowserWindow {
+    mainWindow: BrowserWindow;
+    openWindow: Function;
+    store: Store;
+    openDevTools: Function;
 }

--- a/app/extensions/safe/auth-api/ffiLoader.ts
+++ b/app/extensions/safe/auth-api/ffiLoader.ts
@@ -1,6 +1,5 @@
-import lib from '../ffi/lib';
+import libLoader from '../ffi/lib';
 
 /* eslint-disable import/prefer-default-export */
-export const loadLibrary = ( isMock = false, libPath ) =>
-    lib.load( isMock, libPath );
+export const loadLibrary = ( isMock = false ) => libLoader.load( isMock );
 /* eslint-enable import/prefer-default-export */

--- a/app/extensions/safe/components/webIdDropdown/WebIdDropdown.tsx
+++ b/app/extensions/safe/components/webIdDropdown/WebIdDropdown.tsx
@@ -14,12 +14,37 @@ const webIdManagerUri = startedRunningMock
     ? 'http://localhost:1234'
     : 'safe://webidmgr.dapp';
 const authHomeUri = 'safe-auth://home';
-export class WebIdDropdown extends Component<{}, {}> {
+
+interface WebIdDropdownProps {
+    safeBrowserApp: {
+        webIds: Array<any>;
+        showingWebIdDropdown: boolean;
+        experimentsEnabled: boolean;
+        appStatus: string;
+        networkStatus: number;
+        isFetchingWebIds: boolean;
+    };
+    activeTab: {
+        webId: number;
+    };
+    addTab: Function;
+    getAvailableWebIds: Function;
+    updateTab: Function;
+    showWebIdDropdown: Function;
+    windowId: number;
+}
+export class WebIdDropdown extends Component<WebIdDropdownProps, {}> {
     static defaultProps = {
         safeBrowserApp: {
             webIds: []
         }
     };
+
+    private debouncedGetWebIds: Function;
+
+    private hoverTime: number;
+
+    private isMouseOverIdButton: boolean;
 
     constructor( props ) {
         super( props );
@@ -28,7 +53,7 @@ export class WebIdDropdown extends Component<{}, {}> {
         this.debouncedGetWebIds = _.debounce( getAvailableWebIds, 2000 );
     }
 
-    handleIdClick = webId => {
+    handleIdClick = ( webId ) => {
         const { updateTab, windowId, showWebIdDropdown } = this.props;
         // also if only 1 webID? mark as defualt?
         updateTab( { windowId, webId } );
@@ -36,7 +61,7 @@ export class WebIdDropdown extends Component<{}, {}> {
 
     handleIdButtonClick = () => {
         const { showWebIdDropdown } = this.props;
-        this.hoverTime = new Date();
+        this.hoverTime = new Date().getTime();
         showWebIdDropdown( true );
     };
 
@@ -94,7 +119,7 @@ export class WebIdDropdown extends Component<{}, {}> {
         } = safeBrowserApp;
         const activeWebId = activeTab.webId || {};
         const { handleIdClick } = this;
-        const webIdsList = webIds.map( webId => {
+        const webIdsList = webIds.map( ( webId ) => {
             const nickname = webId['#me'].nick || webId['#me'].name;
             const isSelected = webId['@id'] === activeWebId['@id'];
             if ( isSelected ) {

--- a/app/extensions/safe/ffi/authenticator.ts
+++ b/app/extensions/safe/ffi/authenticator.ts
@@ -22,18 +22,18 @@ import errConst from '../err-constants';
 
 import { isRunningNodeEnvTest } from '$Constants';
 // private variables
-const _registeredClientHandle = Symbol( 'registeredClientHandle' );
-const _nwState = Symbol( 'nwState' );
-const _appListUpdateListener = Symbol( 'appListUpdate' );
-const _authReqListener = Symbol( 'authReq' );
-const _containerReqListener = Symbol( 'containerReq' );
-const _mDataReqListener = Symbol( 'mDataReq' );
-const _nwStateChangeListener = Symbol( 'nwStateChangeListener' );
-const _isAuthorisedListener = Symbol( 'isAuthorisedListener' );
-const _reqErrListener = Symbol( 'reqErrListener' );
-const _cbRegistry = Symbol( 'cbRegistry' );
-const _netDisconnectCb = Symbol( 'netDisconnectCb' );
-const _decodeReqPool = Symbol( 'decodeReqPool' );
+const _registeredClientHandle = Symbol('registeredClientHandle');
+const _nwState = Symbol('nwState');
+const _appListUpdateListener = Symbol('appListUpdate');
+const _authReqListener = Symbol('authReq');
+const _containerReqListener = Symbol('containerReq');
+const _mDataReqListener = Symbol('mDataReq');
+const _nwStateChangeListener = Symbol('nwStateChangeListener');
+const _isAuthorisedListener = Symbol('isAuthorisedListener');
+const _reqErrListener = Symbol('reqErrListener');
+const _cbRegistry = Symbol('cbRegistry');
+const _netDisconnectCb = Symbol('netDisconnectCb');
+const _decodeReqPool = Symbol('decodeReqPool');
 
 /**
  * @private
@@ -41,1102 +41,1102 @@ const _decodeReqPool = Symbol( 'decodeReqPool' );
  * characters or symbols which are not valid for a URL like '=' sign,
  * and making it lower case.
  */
-const genAppUri = str => {
-    const urlSafeBase64 = new Buffer( str )
-        .toString( 'base64' )
-        .replace( /\+/g, '-' ) // Convert '+' to '-'
-        .replace( /\//g, '_' ) // Convert '/' to '_'
-        .replace( /=+$/, '' ) // Remove ending '='
-        .toLowerCase();
-    return `safe-${urlSafeBase64}`;
+const genAppUri = (str) => {
+  const urlSafeBase64 = new Buffer(str)
+    .toString('base64')
+    .replace(/\+/g, '-') // Convert '+' to '-'
+    .replace(/\//g, '_') // Convert '/' to '_'
+    .replace(/=+$/, '') // Remove ending '='
+    .toLowerCase();
+  return `safe-${urlSafeBase64}`;
 };
 
 class Authenticator extends SafeLib {
-    constructor() {
-        super();
-        this[_registeredClientHandle] = null;
-        this[_nwState] = CONSTANTS.NETWORK_STATUS.DISCONNECTED;
-        this[_appListUpdateListener] = new Listener();
-        this[_authReqListener] = new Listener();
-        this[_containerReqListener] = new Listener();
-        this[_mDataReqListener] = new Listener();
-        this[_nwStateChangeListener] = new Listener();
-        this[_reqErrListener] = new Listener();
-        this[_isAuthorisedListener] = new Listener();
-        this[_cbRegistry] = {};
-        this[_decodeReqPool] = {};
-        this[_netDisconnectCb] = ffi.Callback(
-            types.Void,
-            [types.voidPointer, types.int32, types.int32],
-            () => {
-                this._pushNetworkState( CONSTANTS.NETWORK_STATUS.DISCONNECTED );
-            }
-        );
-    }
+  constructor() {
+    super();
+    this[_registeredClientHandle] = null;
+    this[_nwState] = CONSTANTS.NETWORK_STATUS.DISCONNECTED;
+    this[_appListUpdateListener] = new Listener();
+    this[_authReqListener] = new Listener();
+    this[_containerReqListener] = new Listener();
+    this[_mDataReqListener] = new Listener();
+    this[_nwStateChangeListener] = new Listener();
+    this[_reqErrListener] = new Listener();
+    this[_isAuthorisedListener] = new Listener();
+    this[_cbRegistry] = {};
+    this[_decodeReqPool] = {};
+    this[_netDisconnectCb] = ffi.Callback(
+      types.Void,
+      [types.voidPointer, types.int32, types.int32],
+      () => {
+        this._pushNetworkState(CONSTANTS.NETWORK_STATUS.DISCONNECTED);
+      }
+    );
+  }
 
-    get registeredClientHandle() {
-        return this[_registeredClientHandle];
-    }
+  get registeredClientHandle() {
+    return this[_registeredClientHandle];
+  }
 
-    set registeredClientHandle( handle ) {
-        this[_registeredClientHandle] = handle;
-    }
+  set registeredClientHandle(handle) {
+    this[_registeredClientHandle] = handle;
+  }
 
-    get networkState() {
-        return this[_nwState];
-    }
+  get networkState() {
+    return this[_nwState];
+  }
 
-    set networkState( state ) {
-        if ( typeof state === 'undefined' ) {
-            return;
-        }
-        this[_nwState] = state;
+  set networkState(state) {
+    if (typeof state === 'undefined') {
+      return;
     }
+    this[_nwState] = state;
+  }
 
-    get networkDisconnectCb() {
-        return this[_netDisconnectCb];
-    }
+  get networkDisconnectCb() {
+    return this[_netDisconnectCb];
+  }
 
-    getLibStatus() {
-        return this.isLibLoaded;
-    }
+  getLibStatus() {
+    return this.isLibLoaded;
+  }
 
-    fnsToRegister() {
-        return {
-            create_acc: [
-                types.Void,
-                [
-                    types.CString,
-                    types.CString,
-                    types.CString,
-                    types.voidPointer,
-                    'pointer',
-                    'pointer'
-                ]
-            ],
-            login: [
-                types.Void,
-                [types.CString, types.CString, types.voidPointer, 'pointer', 'pointer']
-            ],
-            auth_decode_ipc_msg: [
-                types.Void,
-                [
-                    types.voidPointer,
-                    types.CString,
-                    types.voidPointer,
-                    'pointer',
-                    'pointer',
-                    'pointer',
-                    'pointer',
-                    'pointer'
-                ]
-            ],
-            encode_auth_resp: [
-                types.Void,
-                [
-                    types.voidPointer,
-                    types.AuthReqPointer,
-                    types.u32,
-                    types.bool,
-                    types.voidPointer,
-                    'pointer'
-                ]
-            ],
-            encode_containers_resp: [
-                types.Void,
-                [
-                    types.voidPointer,
-                    types.ContainersReqPointer,
-                    types.u32,
-                    types.bool,
-                    types.voidPointer,
-                    'pointer'
-                ]
-            ],
-            auth_unregistered_decode_ipc_msg: [
-                types.Void,
-                [types.CString, types.voidPointer, 'pointer', 'pointer']
-            ],
-            encode_share_mdata_resp: [
-                types.Void,
-                [
-                    types.voidPointer,
-                    types.ShareMDataReqPointer,
-                    types.u32,
-                    types.bool,
-                    'pointer',
-                    'pointer'
-                ]
-            ],
-            encode_unregistered_resp: [
-                types.Void,
-                [types.u32, types.bool, types.voidPointer, 'pointer']
-            ],
-            auth_registered_apps: [
-                types.Void,
-                [types.voidPointer, types.voidPointer, 'pointer']
-            ],
-            auth_revoke_app: [
-                types.Void,
-                [types.voidPointer, types.CString, types.voidPointer, 'pointer']
-            ],
-            auth_apps_accessing_mutable_data: [
-                types.Void,
-                [types.voidPointer, 'pointer', types.u64, 'pointer', 'pointer']
-            ],
-            auth_free: [types.Void, [types.voidPointer]],
-            auth_init_logging: [
-                types.Void,
-                [types.CString, types.voidPointer, 'pointer']
-            ],
-            auth_set_additional_search_path: [
-                types.Void,
-                [types.CString, types.voidPointer, 'pointer']
-            ],
-            auth_reconnect: [
-                types.Void,
-                [types.voidPointer, types.voidPointer, 'pointer']
-            ],
-            auth_account_info: [types.Void, [types.voidPointer, 'pointer', 'pointer']]
-        };
-    }
+  fnsToRegister() {
+    return {
+      create_acc: [
+        types.Void,
+        [
+          types.CString,
+          types.CString,
+          types.CString,
+          types.voidPointer,
+          'pointer',
+          'pointer'
+        ]
+      ],
+      login: [
+        types.Void,
+        [types.CString, types.CString, types.voidPointer, 'pointer', 'pointer']
+      ],
+      auth_decode_ipc_msg: [
+        types.Void,
+        [
+          types.voidPointer,
+          types.CString,
+          types.voidPointer,
+          'pointer',
+          'pointer',
+          'pointer',
+          'pointer',
+          'pointer'
+        ]
+      ],
+      encode_auth_resp: [
+        types.Void,
+        [
+          types.voidPointer,
+          types.AuthReqPointer,
+          types.u32,
+          types.bool,
+          types.voidPointer,
+          'pointer'
+        ]
+      ],
+      encode_containers_resp: [
+        types.Void,
+        [
+          types.voidPointer,
+          types.ContainersReqPointer,
+          types.u32,
+          types.bool,
+          types.voidPointer,
+          'pointer'
+        ]
+      ],
+      auth_unregistered_decode_ipc_msg: [
+        types.Void,
+        [types.CString, types.voidPointer, 'pointer', 'pointer']
+      ],
+      encode_share_mdata_resp: [
+        types.Void,
+        [
+          types.voidPointer,
+          types.ShareMDataReqPointer,
+          types.u32,
+          types.bool,
+          'pointer',
+          'pointer'
+        ]
+      ],
+      encode_unregistered_resp: [
+        types.Void,
+        [types.u32, types.bool, types.voidPointer, 'pointer']
+      ],
+      auth_registered_apps: [
+        types.Void,
+        [types.voidPointer, types.voidPointer, 'pointer']
+      ],
+      auth_revoke_app: [
+        types.Void,
+        [types.voidPointer, types.CString, types.voidPointer, 'pointer']
+      ],
+      auth_apps_accessing_mutable_data: [
+        types.Void,
+        [types.voidPointer, 'pointer', types.u64, 'pointer', 'pointer']
+      ],
+      auth_free: [types.Void, [types.voidPointer]],
+      auth_init_logging: [
+        types.Void,
+        [types.CString, types.voidPointer, 'pointer']
+      ],
+      auth_set_additional_search_path: [
+        types.Void,
+        [types.CString, types.voidPointer, 'pointer']
+      ],
+      auth_reconnect: [
+        types.Void,
+        [types.voidPointer, types.voidPointer, 'pointer']
+      ],
+      auth_account_info: [types.Void, [types.voidPointer, 'pointer', 'pointer']]
+    };
+  }
 
-    setListener( type, cb ) {
+  setListener(type, cb) {
     // FIXME check .key required
-        switch ( type.key ) {
-            case CONSTANTS.LISTENER_TYPES.APP_LIST_UPDATE.key: {
-                return this[_appListUpdateListener].add( cb );
+    switch (type.key) {
+      case CONSTANTS.LISTENER_TYPES.APP_LIST_UPDATE.key: {
+        return this[_appListUpdateListener].add(cb);
+      }
+      case CONSTANTS.LISTENER_TYPES.AUTH_REQ.key: {
+        return this[_authReqListener].add(cb);
+      }
+      case CONSTANTS.LISTENER_TYPES.CONTAINER_REQ.key: {
+        return this[_containerReqListener].add(cb);
+      }
+      case CONSTANTS.LISTENER_TYPES.MDATA_REQ.key: {
+        return this[_mDataReqListener].add(cb);
+      }
+      case CONSTANTS.LISTENER_TYPES.NW_STATE_CHANGE.key: {
+        return this[_nwStateChangeListener].add(cb);
+      }
+      case CONSTANTS.LISTENER_TYPES.REQUEST_ERR.key: {
+        return this[_reqErrListener].add(cb);
+      }
+      case CONSTANTS.LISTENER_TYPES.IS_AUTHORISED.key: {
+        return this[_isAuthorisedListener].add(cb);
+      }
+      default: {
+        throw new Error(errConst.INVALID_LISTENER.msg);
+      }
+    }
+  }
+
+  removeListener(type, id) {
+    switch (type.key) {
+      case CONSTANTS.LISTENER_TYPES.APP_LIST_UPDATE.key: {
+        return this[_appListUpdateListener].remove(id);
+      }
+      case CONSTANTS.LISTENER_TYPES.AUTH_REQ.key: {
+        return this[_authReqListener].remove(id);
+      }
+      case CONSTANTS.LISTENER_TYPES.CONTAINER_REQ.key: {
+        return this[_containerReqListener].remove(id);
+      }
+      case CONSTANTS.LISTENER_TYPES.NW_STATE_CHANGE.key: {
+        return this[_nwStateChangeListener].remove(id);
+      }
+      case CONSTANTS.LISTENER_TYPES.REQUEST_ERR.key: {
+        return this[_reqErrListener].remove(id);
+      }
+      case CONSTANTS.LISTENER_TYPES.IS_AUTHORISED.key: {
+        return this[_isAuthorisedListener].remove(id);
+      }
+      default: {
+        throw new Error(errConst.INVALID_LISTENER.msg);
+      }
+    }
+  }
+
+  reconnect() {
+    return new Promise((resolve, reject) => {
+      if (!this.registeredClientHandle) {
+        return reject(new Error(i18n.__('messages.unauthorised')));
+      }
+      try {
+        const cb = this._pushCb(
+          ffi.Callback(
+            types.Void,
+            [types.voidPointer, types.FfiResultPointer],
+            (userData, resultPtr) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0) {
+                return reject(JSON.stringify(result));
+              }
+              this._pushNetworkState(CONSTANTS.NETWORK_STATUS.CONNECTED);
+              resolve();
             }
-            case CONSTANTS.LISTENER_TYPES.AUTH_REQ.key: {
-                return this[_authReqListener].add( cb );
+          )
+        );
+
+        this.safeLib.auth_reconnect(
+          this.registeredClientHandle,
+          types.Null,
+          this._getCb(cb)
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  createAccount(locator, secret, invitation) {
+    return new Promise((resolve, reject) => {
+      const validationErr = this._isUserCredentialsValid(locator, secret);
+      if (validationErr) {
+        return reject(validationErr);
+      }
+
+      if (
+        !(invitation && typeof invitation === 'string' && invitation.trim())
+      ) {
+        return Promise.reject(
+          new Error(i18n.__('messages.invalid_invite_code'))
+        );
+      }
+
+      try {
+        const createAccCb = this._pushCb(
+          ffi.Callback(
+            types.Void,
+            [
+              types.voidPointer,
+              types.FfiResultPointer,
+              types.ClientHandlePointer
+            ],
+            (userData, resultPtr, clientHandle) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0 && clientHandle.length === 0) {
+                return reject(JSON.stringify(result));
+              }
+              this.registeredClientHandle = clientHandle;
+              this._pushNetworkState(CONSTANTS.NETWORK_STATUS.CONNECTED);
+              resolve();
             }
-            case CONSTANTS.LISTENER_TYPES.CONTAINER_REQ.key: {
-                return this[_containerReqListener].add( cb );
+          )
+        );
+
+        const onResult = (err, res) => {
+          if (err || res !== 0) {
+            return reject(err);
+          }
+        };
+
+        this.safeLib.create_acc.async(
+          types.allocCString(locator),
+          types.allocCString(secret),
+          types.allocCString(invitation),
+          types.Null,
+          this.networkDisconnectCb,
+          this._getCb(createAccCb),
+          onResult
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  login(locator, secret) {
+    return new Promise((resolve, reject) => {
+      const validationErr = this._isUserCredentialsValid(locator, secret);
+      if (validationErr) {
+        return reject(validationErr);
+      }
+
+      try {
+        const loginCb = this._pushCb(
+          ffi.Callback(
+            types.Void,
+            [
+              types.voidPointer,
+              types.FfiResultPointer,
+              types.ClientHandlePointer
+            ],
+            (userData, resultPtr, clientHandle) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0 && clientHandle.length === 0) {
+                this[_isAuthorisedListener].broadcast(result);
+                return reject(JSON.stringify(result));
+              }
+              this.registeredClientHandle = clientHandle;
+              this._pushNetworkState(CONSTANTS.NETWORK_STATUS.CONNECTED);
+              this[_isAuthorisedListener].broadcast(null, true);
+
+              resolve();
             }
-            case CONSTANTS.LISTENER_TYPES.MDATA_REQ.key: {
-                return this[_mDataReqListener].add( cb );
-            }
-            case CONSTANTS.LISTENER_TYPES.NW_STATE_CHANGE.key: {
-                return this[_nwStateChangeListener].add( cb );
-            }
-            case CONSTANTS.LISTENER_TYPES.REQUEST_ERR.key: {
-                return this[_reqErrListener].add( cb );
-            }
-            case CONSTANTS.LISTENER_TYPES.IS_AUTHORISED.key: {
-                return this[_isAuthorisedListener].add( cb );
-            }
-            default: {
-                throw new Error( errConst.INVALID_LISTENER.msg );
-            }
+          )
+        );
+
+        const onResult = (err, res) => {
+          if (err || res !== 0) {
+            this[_isAuthorisedListener].broadcast(err);
+            return reject(err);
+          }
+        };
+
+        this.safeLib.login.async(
+          types.allocCString(locator),
+          types.allocCString(secret),
+          types.Null,
+          this.networkDisconnectCb,
+          this._getCb(loginCb),
+          onResult
+        );
+      } catch (e) {
+        logger.info('Login error', e);
+        this[_isAuthorisedListener].broadcast(e);
+        reject(e);
+      }
+    });
+  }
+
+  logout() {
+    return new Promise((resolve, reject) => {
+      try {
+        this._pushNetworkState(CONSTANTS.NETWORK_STATUS.DISCONNECTED);
+
+        if (!isRunningNodeEnvTest) {
+          // TODO: Why does this crash testing?
+          this.safeLib.auth_free(this.registeredClientHandle);
         }
-    }
 
-    removeListener( type, id ) {
-        switch ( type.key ) {
-            case CONSTANTS.LISTENER_TYPES.APP_LIST_UPDATE.key: {
-                return this[_appListUpdateListener].remove( id );
-            }
-            case CONSTANTS.LISTENER_TYPES.AUTH_REQ.key: {
-                return this[_authReqListener].remove( id );
-            }
-            case CONSTANTS.LISTENER_TYPES.CONTAINER_REQ.key: {
-                return this[_containerReqListener].remove( id );
-            }
-            case CONSTANTS.LISTENER_TYPES.NW_STATE_CHANGE.key: {
-                return this[_nwStateChangeListener].remove( id );
-            }
-            case CONSTANTS.LISTENER_TYPES.REQUEST_ERR.key: {
-                return this[_reqErrListener].remove( id );
-            }
-            case CONSTANTS.LISTENER_TYPES.IS_AUTHORISED.key: {
-                return this[_isAuthorisedListener].remove( id );
-            }
-            default: {
-                throw new Error( errConst.INVALID_LISTENER.msg );
-            }
-        }
-    }
+        this.registeredClientHandle = null;
+        this[_isAuthorisedListener].broadcast(null, false);
+        resolve();
+      } catch (e) {
+        this[_isAuthorisedListener].broadcast(e);
+        reject(e);
+      }
+    });
+  }
 
-    reconnect() {
-        return new Promise( ( resolve, reject ) => {
-            if ( !this.registeredClientHandle ) {
-                return reject( new Error( i18n.__( 'messages.unauthorised' ) ) );
-            }
-            try {
-                const cb = this._pushCb(
-                    ffi.Callback(
-                        types.Void,
-                        [types.voidPointer, types.FfiResultPointer],
-                        ( userData, resultPtr ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 ) {
-                                return reject( JSON.stringify( result ) );
-                            }
-                            this._pushNetworkState( CONSTANTS.NETWORK_STATUS.CONNECTED );
-                            resolve();
-                        }
-                    )
-                );
+  decodeRequest(uri) {
+    logger.info('Authenticator.js decoding request', uri);
 
-                this.safeLib.auth_reconnect(
-                    this.registeredClientHandle,
-                    types.Null,
-                    this._getCb( cb )
-                );
-            } catch ( e ) {
-                reject( e );
-            }
-        } );
-    }
+    return new Promise((resolve, reject) => {
+      if (!uri) {
+        return reject(new Error(errConst.INVALID_URI.msg));
+      }
+      const parsedURI = uri
+        .replace('safe-auth://', '')
+        .replace('safe-auth:', '')
+        .replace('/', '');
 
-    createAccount( locator, secret, invitation ) {
-        return new Promise( ( resolve, reject ) => {
-            const validationErr = this._isUserCredentialsValid( locator, secret );
-            if ( validationErr ) {
-                return reject( validationErr );
-            }
+      if (!this.registeredClientHandle) {
+        return this._decodeUnRegisteredRequest(parsedURI, resolve, reject);
+      }
 
+      const decodeReqAuthCb = this._pushCb(
+        ffi.Callback(
+          types.Void,
+          [types.voidPointer, types.u32, types.AuthReqPointer],
+          (userData, reqId, req) => {
             if (
-                !( invitation && typeof invitation === 'string' && invitation.trim() )
+              !(this[_authReqListener] && this[_authReqListener].len() !== 0)
             ) {
-                return Promise.reject(
-                    new Error( i18n.__( 'messages.invalid_invite_code' ) )
-                );
+              return;
             }
-
-            try {
-                const createAccCb = this._pushCb(
-                    ffi.Callback(
-                        types.Void,
-                        [
-                            types.voidPointer,
-                            types.FfiResultPointer,
-                            types.ClientHandlePointer
-                        ],
-                        ( userData, resultPtr, clientHandle ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 && clientHandle.length === 0 ) {
-                                return reject( JSON.stringify( result ) );
-                            }
-                            this.registeredClientHandle = clientHandle;
-                            this._pushNetworkState( CONSTANTS.NETWORK_STATUS.CONNECTED );
-                            resolve();
-                        }
-                    )
-                );
-
-                const onResult = ( err, res ) => {
-                    if ( err || res !== 0 ) {
-                        return reject( err );
-                    }
-                };
-
-                this.safeLib.create_acc.async(
-                    types.allocCString( locator ),
-                    types.allocCString( secret ),
-                    types.allocCString( invitation ),
-                    types.Null,
-                    this.networkDisconnectCb,
-                    this._getCb( createAccCb ),
-                    onResult
-                );
-            } catch ( e ) {
-                reject( e );
-            }
-        } );
-    }
-
-    login( locator, secret ) {
-        return new Promise( ( resolve, reject ) => {
-            const validationErr = this._isUserCredentialsValid( locator, secret );
-            if ( validationErr ) {
-                return reject( validationErr );
-            }
-
-            try {
-                const loginCb = this._pushCb(
-                    ffi.Callback(
-                        types.Void,
-                        [
-                            types.voidPointer,
-                            types.FfiResultPointer,
-                            types.ClientHandlePointer
-                        ],
-                        ( userData, resultPtr, clientHandle ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 && clientHandle.length === 0 ) {
-                                this[_isAuthorisedListener].broadcast( result );
-                                return reject( JSON.stringify( result ) );
-                            }
-                            this.registeredClientHandle = clientHandle;
-                            this._pushNetworkState( CONSTANTS.NETWORK_STATUS.CONNECTED );
-                            this[_isAuthorisedListener].broadcast( null, true );
-
-                            resolve();
-                        }
-                    )
-                );
-
-                const onResult = ( err, res ) => {
-                    if ( err || res !== 0 ) {
-                        this[_isAuthorisedListener].broadcast( err );
-                        return reject( err );
-                    }
-                };
-
-                this.safeLib.login.async(
-                    types.allocCString( locator ),
-                    types.allocCString( secret ),
-                    types.Null,
-                    this.networkDisconnectCb,
-                    this._getCb( loginCb ),
-                    onResult
-                );
-            } catch ( e ) {
-                logger.info( 'Login error', e );
-                this[_isAuthorisedListener].broadcast( e );
-                reject( e );
-            }
-        } );
-    }
-
-    logout() {
-        return new Promise( ( resolve, reject ) => {
-            try {
-                this._pushNetworkState( CONSTANTS.NETWORK_STATUS.DISCONNECTED );
-
-                if ( !isRunningNodeEnvTest ) {
-                    // TODO: Why does this crash testing?
-                    this.safeLib.auth_free( this.registeredClientHandle );
-                }
-
-                this.registeredClientHandle = null;
-                this[_isAuthorisedListener].broadcast( null, false );
-                resolve();
-            } catch ( e ) {
-                this[_isAuthorisedListener].broadcast( e );
-                reject( e );
-            }
-        } );
-    }
-
-    decodeRequest( uri ) {
-        logger.info( 'Authenticator.js decoding request', uri );
-
-        return new Promise( ( resolve, reject ) => {
-            if ( !uri ) {
-                return reject( new Error( errConst.INVALID_URI.msg ) );
-            }
-            const parsedURI = uri
-                .replace( 'safe-auth://', '' )
-                .replace( 'safe-auth:', '' )
-                .replace( '/', '' );
-
-            if ( !this.registeredClientHandle ) {
-                return this._decodeUnRegisteredRequest( parsedURI, resolve, reject );
-            }
-
-            const decodeReqAuthCb = this._pushCb(
-                ffi.Callback(
-                    types.Void,
-                    [types.voidPointer, types.u32, types.AuthReqPointer],
-                    ( userData, reqId, req ) => {
-                        if (
-                            !( this[_authReqListener] && this[_authReqListener].len() !== 0 )
-                        ) {
-                            return;
-                        }
-                        const authReq = typeParser.parseAuthReq( req.deref() );
-                        this[_decodeReqPool][reqId] = authReq;
-                        const result = {
-                            reqId,
-                            authReq
-                        };
-                        logger.info( 'Authenticator.js decoded authReq result: ', result );
-                        return this._isAlreadyAuthorised( authReq ).then( resolved => {
-                            if ( resolved.isAuthorised ) {
-                                result.isAuthorised = true;
-                                if ( resolved.previouslyAuthorisedContainers ) {
-                                    result.previouslyAuthorisedContainers =
+            const authReq = typeParser.parseAuthReq(req.deref());
+            this[_decodeReqPool][reqId] = authReq;
+            const result = {
+              reqId,
+              authReq
+            };
+            logger.info('Authenticator.js decoded authReq result: ', result);
+            return this._isAlreadyAuthorised(authReq).then((resolved) => {
+              if (resolved.isAuthorised) {
+                result.isAuthorised = true;
+                if (resolved.previouslyAuthorisedContainers) {
+                  result.previouslyAuthorisedContainers =
                     resolved.previouslyAuthorisedContainers;
-                                }
-                            }
-                            return resolve( result );
-                        } );
-                    }
-                )
-            );
+                }
+              }
+              return resolve(result);
+            });
+          }
+        )
+      );
 
-            const decodeReqContainerCb = this._pushCb(
-                ffi.Callback(
-                    types.Void,
-                    [types.voidPointer, types.u32, types.ContainersReqPointer],
-                    ( userData, reqId, req ) => {
-                        if (
-                            !(
-                                this[_containerReqListener] &&
-                this[_containerReqListener].len() !== 0
-                            )
-                        ) {
-                            return;
-                        }
-                        const contReq = typeParser.parseContainerReq( req.deref() );
-                        this[_decodeReqPool][reqId] = contReq;
-                        const result = {
-                            reqId,
-                            contReq
-                        };
-
-                        logger.info( 'Authenticator.js decoded contReq result: ', result );
-
-                        return this._isAlreadyAuthorisedContainer( contReq ).then(
-                            isAuthorised => {
-                                if ( isAuthorised ) {
-                                    result.isAuthorised = true;
-                                }
-                                return resolve( result );
-                            }
-                        );
-                    }
-                )
-            );
-
-            const shareMdataCb = this._pushCb(
-                ffi.Callback(
-                    types.Void,
-                    [types.voidPointer, types.u32, types.ShareMDataReqPointer, 'pointer'],
-                    async ( userData, reqId, req, meta ) => {
-                        const mDataReq = typeParser.parseShareMDataReq( req.deref() );
-                        const metaData = typeParser.parseUserMetaDataArray(
-                            meta,
-                            mDataReq.mdata_len
-                        );
-                        this[_decodeReqPool][reqId] = mDataReq;
-                        const result = {
-                            reqId,
-                            mDataReq,
-                            metaData
-                        };
-
-                        logger.info( 'Authenticator.js decoded MDataReq result: ', result );
-
-                        const appAccess = [];
-                        const tempArr = [];
-                        for ( let i = 0; i < mDataReq.mdata_len; i++ ) {
-                            tempArr[i] = i;
-                        }
-
-                        await Promise.all(
-                            tempArr.map( i => {
-                                const mdata = mDataReq.mdata[i];
-                                return this._appsAccessingMData(
-                                    mdata.name,
-                                    mdata.type_tag
-                                ).then( res => {
-                                    appAccess[i] = res;
-                                } );
-                            } )
-                        );
-                        result.appAccess = appAccess;
-                        return resolve( result );
-                    }
-                )
-            );
-
-            const unregisteredCb = this._getUnregisteredClientCb( resolve, reject );
-
-            const decodeReqErrorCb = this._pushCb(
-                ffi.Callback(
-                    types.Void,
-                    [types.voidPointer, types.FfiResultPointer, types.CString],
-                    ( userData, resultPtr ) => {
-                        const result = resultPtr.deref();
-                        const error = {
-                            error_code: result.error_code,
-                            description: result.description
-                        };
-                        if ( !( this[_reqErrListener] && this[_reqErrListener].len() !== 0 ) ) {
-                            return;
-                        }
-
-                        this[_reqErrListener].broadcast( JSON.stringify( error ) );
-                        return reject( error );
-                    }
-                )
-            );
-            try {
-                this.safeLib.auth_decode_ipc_msg(
-                    this.registeredClientHandle,
-                    types.allocCString( parsedURI ),
-                    types.Null,
-                    this._getCb( decodeReqAuthCb ),
-                    this._getCb( decodeReqContainerCb ),
-                    this._getCb( unregisteredCb ),
-                    this._getCb( shareMdataCb ),
-                    this._getCb( decodeReqErrorCb )
-                );
-            } catch ( e ) {
-                reject( e );
-            }
-        } );
-    }
-
-    encodeAuthResp( req, isAllowed ) {
-        return new Promise( ( resolve, reject ) => {
-            logger.info( 'authenticator.js: encoding auth response', req, isAllowed );
-
-            if ( !this.registeredClientHandle ) {
-                return reject( new Error( i18n.__( 'messages.unauthorised' ) ) );
-            }
-
-            if ( !req || typeof isAllowed !== 'boolean' ) {
-                return reject( new Error( i18n.__( 'messages.invalid_params' ) ) );
-            }
-
-            if ( !req.reqId || !this[_decodeReqPool][req.reqId] ) {
-                return reject( new Error( i18n.__( 'messages.invalid_req' ) ) );
-            }
-
-            const authReq = types.allocAuthReq(
-                typeConstructor.constructAuthReq( this[_decodeReqPool][req.reqId] )
-            );
-
-            delete this[_decodeReqPool][req.reqId];
-
-            try {
-                const authDecisionCb = this._pushCb(
-                    ffi.Callback(
-                        types.Void,
-                        [types.voidPointer, types.FfiResultPointer, types.CString],
-                        ( userData, resultPtr, res ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 ) {
-                                return reject( JSON.stringify( result ) );
-                            }
-
-                            logger.info(
-                                'authenticator.js: auth decision CB',
-                                result,
-                                isAllowed
-                            );
-
-                            if ( isAllowed ) {
-                                this._updateAppList();
-                            }
-                            const appUri = genAppUri( req.authReq.app.id );
-                            resolve( `${appUri}:${res}` );
-                        }
-                    )
-                );
-                this.safeLib.encode_auth_resp(
-                    this.registeredClientHandle,
-                    authReq,
-                    req.reqId,
-                    isAllowed,
-                    types.Null,
-                    this._getCb( authDecisionCb )
-                );
-            } catch ( e ) {
-                reject( e );
-            }
-        } );
-    }
-
-    encodeContainersResp( req, isAllowed ) {
-        return new Promise( ( resolve, reject ) => {
-            if ( !this.registeredClientHandle ) {
-                return reject( new Error( i18n.__( 'messages.unauthorised' ) ) );
-            }
-
-            if ( !req || typeof isAllowed !== 'boolean' ) {
-                return reject( new Error( i18n.__( 'messages.invalid_params' ) ) );
-            }
-
-            if ( !req.reqId || !this[_decodeReqPool][req.reqId] ) {
-                return reject( new Error( i18n.__( 'messages.invalid_req' ) ) );
-            }
-            const contReq = types.allocContainerReq(
-                typeConstructor.constructContainerReq( this[_decodeReqPool][req.reqId] )
-            );
-
-            delete this[_decodeReqPool][req.reqId];
-
-            try {
-                const contDecisionCb = this._pushCb(
-                    ffi.Callback(
-                        types.Void,
-                        [types.voidPointer, types.FfiResultPointer, types.CString],
-                        ( userData, resultPtr, res ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 ) {
-                                return reject( JSON.stringify( result ) );
-                            }
-                            if ( isAllowed ) {
-                                this._updateAppList();
-                            }
-                            const appUri = genAppUri( req.contReq.app.id );
-                            resolve( `${appUri}:${res}` );
-                        }
-                    )
-                );
-
-                this.safeLib.encode_containers_resp(
-                    this.registeredClientHandle,
-                    contReq,
-                    req.reqId,
-                    isAllowed,
-                    types.Null,
-                    this._getCb( contDecisionCb )
-                );
-            } catch ( e ) {
-                reject( e );
-            }
-        } );
-    }
-
-    encodeMDataResp( req, isAllowed ) {
-        console.log( 'asdadad' );
-        logger.info( 'doing this', req, isAllowed );
-        return new Promise( ( resolve, reject ) => {
-            if ( !this.registeredClientHandle ) {
-                return reject( new Error( i18n.__( 'messages.unauthorised' ) ) );
-            }
-
-            if ( !req || typeof isAllowed !== 'boolean' ) {
-                return reject( new Error( i18n.__( 'messages.invalid_params' ) ) );
-            }
-
-            if ( !req.reqId || !this[_decodeReqPool][req.reqId] ) {
-                return reject( new Error( i18n.__( 'messages.invalid_req' ) ) );
-            }
-
-            const mDataReq = types.allocSharedMdataReq(
-                typeConstructor.constructSharedMdataReq( this[_decodeReqPool][req.reqId] )
-            );
-
-            delete this[_decodeReqPool][req.reqId];
-
-            try {
-                const mDataDecisionCb = this._pushCb(
-                    ffi.Callback(
-                        types.Void,
-                        [types.voidPointer, types.FfiResultPointer, types.CString],
-                        ( userData, resultPtr, res ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 ) {
-                                return reject( JSON.stringify( result ) );
-                            }
-                            if ( isAllowed ) {
-                                this._updateAppList();
-                            }
-                            const appUri = genAppUri( req.mDataReq.app.id );
-                            resolve( `${appUri}:${res}` );
-                        }
-                    )
-                );
-
-                this.safeLib.encode_share_mdata_resp(
-                    this.registeredClientHandle,
-                    mDataReq,
-                    req.reqId,
-                    isAllowed,
-                    types.Null,
-                    this._getCb( mDataDecisionCb )
-                );
-            } catch ( e ) {
-                reject( e );
-            }
-        } );
-    }
-
-    revokeApp( appId ) {
-        return new Promise( ( resolve, reject ) => {
-            if ( !this.registeredClientHandle ) {
-                return reject( new Error( i18n.__( 'messages.unauthorised' ) ) );
-            }
-
-            if ( !appId ) {
-                return reject(
-                    new Error( i18n.__( 'messages.should_not_be_empty', i18n.__( 'AppId' ) ) )
-                );
-            }
-
-            if ( typeof appId !== 'string' ) {
-                return reject(
-                    new Error( i18n.__( 'messages.must_be_string', i18n.__( 'AppId' ) ) )
-                );
-            }
-
-            if ( !appId.trim() ) {
-                return reject(
-                    new Error( i18n.__( 'messages.should_not_be_empty', i18n.__( 'AppId' ) ) )
-                );
-            }
-
-            try {
-                const revokeCb = this._pushCb(
-                    ffi.Callback(
-                        types.Void,
-                        [types.voidPointer, types.FfiResultPointer, types.CString],
-                        ( userData, resultPtr, res ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 ) {
-                                return reject( JSON.stringify( result ) );
-                            }
-                            this._updateAppList();
-                            resolve( res );
-                        }
-                    )
-                );
-
-                this.safeLib.auth_revoke_app(
-                    this.registeredClientHandle,
-                    types.allocCString( appId ),
-                    types.Null,
-                    this._getCb( revokeCb )
-                );
-            } catch ( e ) {
-                reject( e.message );
-            }
-        } );
-    }
-
-    getRegisteredApps() {
-        return new Promise( ( resolve, reject ) => {
-            if ( !this.registeredClientHandle ) {
-                return reject( new Error( i18n.__( 'messages.unauthorised' ) ) );
-            }
-            let cb = null;
-            cb = this._pushCb(
-                ffi.Callback(
-                    types.Void,
-                    [
-                        types.voidPointer,
-                        types.FfiResultPointer,
-                        types.RegisteredAppPointer,
-                        types.usize
-                    ],
-                    ( userData, resultPtr, appList, len ) => {
-                        const result = resultPtr.deref();
-                        this._deleteFromCb( cb );
-                        if ( result.error_code !== 0 ) {
-                            return reject( JSON.stringify( result ) );
-                        }
-                        const apps = typeParser.parseRegisteredAppArray( appList, len );
-                        resolve( apps );
-                    }
-                )
-            );
-
-            try {
-                this.safeLib.auth_registered_apps(
-                    this.registeredClientHandle,
-                    types.Null,
-                    this._getCb( cb )
-                );
-            } catch ( e ) {
-                reject( e.message );
-            }
-        } );
-    }
-
-    getAccountInfo() {
-        return new Promise( ( resolve, reject ) => {
-            if ( !this.registeredClientHandle ) {
-                return reject( new Error( i18n.__( 'messages.unauthorised' ) ) );
-            }
-            const cb = this._pushCb(
-                ffi.Callback(
-                    types.Void,
-                    [types.voidPointer, types.FfiResultPointer, types.AccountInfoPointer],
-                    ( userData, resultPtr, accInfo ) => {
-                        const result = resultPtr.deref();
-                        if ( result.error_code !== 0 ) {
-                            return reject( JSON.stringify( result ) );
-                        }
-                        const info = accInfo.deref();
-                        resolve( {
-                            done: info.mutations_done,
-                            available: info.mutations_available
-                        } );
-                    }
-                )
-            );
-
-            try {
-                this.safeLib.auth_account_info(
-                    this.registeredClientHandle,
-                    types.Null,
-                    this._getCb( cb )
-                );
-            } catch ( e ) {
-                reject( e.message );
-            }
-        } );
-    }
-
-    _appsAccessingMData( name, typeTag ) {
-        const nameBuf = types.XorName( Buffer.from( name, 'hex' ) ).buffer;
-        return new Promise( ( resolve, reject ) => {
-            if ( !this.registeredClientHandle ) {
-                return reject( new Error( i18n.__( 'messages.unauthorised' ) ) );
-            }
-            const cb = this._pushCb(
-                ffi.Callback(
-                    types.Void,
-                    [
-                        types.voidPointer,
-                        types.FfiResultPointer,
-                        types.AppAccessPointer,
-                        types.usize
-                    ],
-                    ( userData, resultPtr, appAccess, len ) => {
-                        const result = resultPtr.deref();
-                        if ( result.error_code !== 0 ) {
-                            return reject( JSON.stringify( result ) );
-                        }
-                        const appAccessInfo = typeParser.parseAppAccess( appAccess, len );
-                        return resolve( appAccessInfo );
-                    }
-                )
-            );
-
-            try {
-                this.safeLib.auth_apps_accessing_mutable_data(
-                    this.registeredClientHandle,
-                    nameBuf,
-                    typeTag,
-                    types.Null,
-                    this._getCb( cb )
-                );
-            } catch ( e ) {
-                reject( e.message );
-            }
-        } );
-    }
-
-    _pushCb( cb ) {
-        const rand = crypto.randomBytes( 32 ).toString( 'hex' );
-        this[_cbRegistry][rand] = cb;
-        return rand;
-    }
-
-    _getCb( rand ) {
-        return this[_cbRegistry][rand];
-    }
-
-    _deleteFromCb( rand ) {
-        if ( !this[_cbRegistry][rand] ) {
-            return;
-        }
-        delete this[_cbRegistry][rand];
-    }
-
-    _updateAppList() {
-        this.getRegisteredApps().then( apps => {
+      const decodeReqContainerCb = this._pushCb(
+        ffi.Callback(
+          types.Void,
+          [types.voidPointer, types.u32, types.ContainersReqPointer],
+          (userData, reqId, req) => {
             if (
-                this[_appListUpdateListener] &&
-        this[_appListUpdateListener].len() !== 0
+              !(
+                this[_containerReqListener] &&
+                this[_containerReqListener].len() !== 0
+              )
             ) {
-                this[_appListUpdateListener].broadcast( null, apps );
+              return;
             }
-        } );
-    }
+            const contReq = typeParser.parseContainerReq(req.deref());
+            this[_decodeReqPool][reqId] = contReq;
+            const result = {
+              reqId,
+              contReq
+            };
 
-    _decodeUnRegisteredRequest( parsedUri, resolve, reject ) {
-        if ( !parsedUri ) {
-            return reject( new Error( errConst.INVALID_URI.msg ) );
-        }
+            logger.info('Authenticator.js decoded contReq result: ', result);
 
-        const unregisteredCb = this._getUnregisteredClientCb( resolve, reject );
-
-        const decodeReqErrorCb = this._pushCb(
-            ffi.Callback(
-                types.Void,
-                [types.voidPointer, types.FfiResultPointer, types.CString],
-                () => {
-                    reject( new Error( errConst.UNAUTHORISED.msg ) );
+            return this._isAlreadyAuthorisedContainer(contReq).then(
+              (isAuthorised) => {
+                if (isAuthorised) {
+                  result.isAuthorised = true;
                 }
-            )
-        );
-
-        try {
-            this.safeLib.auth_unregistered_decode_ipc_msg(
-                types.allocCString( parsedUri ),
-                types.Null,
-                this._getCb( unregisteredCb ),
-                this._getCb( decodeReqErrorCb )
+                return resolve(result);
+              }
             );
-        } catch ( err ) {
-            return reject( err );
-        }
-    }
+          }
+        )
+      );
 
-    _encodeUnRegisteredResp( reqId, appId ) {
-        return new Promise( ( resolve, reject ) => {
-            try {
-                const encodeCb = this._pushCb(
-                    ffi.Callback(
-                        types.Void,
-                        [types.voidPointer, types.FfiResultPointer, types.CString],
-                        ( userData, resultPtr, res ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 && !res ) {
-                                return reject( JSON.stringify( result ) );
-                            }
-                            const appUri = genAppUri( appId );
-                            resolve( `${appUri}:${res}` );
-                        }
-                    )
-                );
-                this.safeLib.encode_unregistered_resp(
-                    reqId,
-                    true,
-                    types.Null,
-                    this._getCb( encodeCb )
-                );
-            } catch ( e ) {
-                reject( e.message );
+      const shareMdataCb = this._pushCb(
+        ffi.Callback(
+          types.Void,
+          [types.voidPointer, types.u32, types.ShareMDataReqPointer, 'pointer'],
+          async (userData, reqId, req, meta) => {
+            const mDataReq = typeParser.parseShareMDataReq(req.deref());
+            const metaData = typeParser.parseUserMetaDataArray(
+              meta,
+              mDataReq.mdata_len
+            );
+            this[_decodeReqPool][reqId] = mDataReq;
+            const result = {
+              reqId,
+              mDataReq,
+              metaData
+            };
+
+            logger.info('Authenticator.js decoded MDataReq result: ', result);
+
+            const appAccess = [];
+            const tempArr = [];
+            for (let i = 0; i < mDataReq.mdata_len; i++) {
+              tempArr[i] = i;
             }
-        } );
-    }
 
-    _getUnregisteredClientCb( resolve, reject ) {
-        return this._pushCb(
-            ffi.Callback(
-                types.Void,
-                [types.voidPointer, types.u32, types.u8Pointer, types.usize],
-                ( userData, reqId, appIdPtr, appIdLen ) => {
-                    if ( !reqId || appIdLen <= 0 ) {
-                        return reject( new Error( errConst, INVALID_RESPONSE.msg ) );
-                    }
+            await Promise.all(
+              tempArr.map((i) => {
+                const mdata = mDataReq.mdata[i];
+                return this._appsAccessingMData(
+                  mdata.name,
+                  mdata.type_tag
+                ).then((res) => {
+                  appAccess[i] = res;
+                });
+              })
+            );
+            result.appAccess = appAccess;
+            return resolve(result);
+          }
+        )
+      );
 
-                    const appId = ref.reinterpret( appIdPtr, appIdLen );
-                    return this._encodeUnRegisteredResp( reqId, appId ).then( res =>
-                        resolve( res )
-                    );
-                }
-            )
+      const unregisteredCb = this._getUnregisteredClientCb(resolve, reject);
+
+      const decodeReqErrorCb = this._pushCb(
+        ffi.Callback(
+          types.Void,
+          [types.voidPointer, types.FfiResultPointer, types.CString],
+          (userData, resultPtr) => {
+            const result = resultPtr.deref();
+            const error = {
+              error_code: result.error_code,
+              description: result.description
+            };
+            if (!(this[_reqErrListener] && this[_reqErrListener].len() !== 0)) {
+              return;
+            }
+
+            this[_reqErrListener].broadcast(JSON.stringify(error));
+            return reject(error);
+          }
+        )
+      );
+      try {
+        this.safeLib.auth_decode_ipc_msg(
+          this.registeredClientHandle,
+          types.allocCString(parsedURI),
+          types.Null,
+          this._getCb(decodeReqAuthCb),
+          this._getCb(decodeReqContainerCb),
+          this._getCb(unregisteredCb),
+          this._getCb(shareMdataCb),
+          this._getCb(decodeReqErrorCb)
         );
-    }
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
 
-    _isAlreadyAuthorised( request ) {
-        const req = lodash.cloneDeep( request );
-        return new Promise( ( resolve, reject ) => {
-            try {
-                this.getRegisteredApps()
-                    .then( authorisedApps => {
-                        let previouslyAuthorisedContainers;
-                        const isAuthorised = authorisedApps.some( app => {
-                            const appIsPresent = lodash.isEqual( app.app_info, req.app );
-                            if ( appIsPresent && app.containers ) {
-                                previouslyAuthorisedContainers = app.containers;
-                            }
-                            return appIsPresent;
-                        } );
-                        return {
-                            isAuthorised,
-                            previouslyAuthorisedContainers
-                        };
-                    } )
-                    .then( resolve );
-            } catch ( err ) {
-                return reject( err );
+  encodeAuthResp(req, isAllowed) {
+    return new Promise((resolve, reject) => {
+      logger.info('authenticator.js: encoding auth response', req, isAllowed);
+
+      if (!this.registeredClientHandle) {
+        return reject(new Error(i18n.__('messages.unauthorised')));
+      }
+
+      if (!req || typeof isAllowed !== 'boolean') {
+        return reject(new Error(i18n.__('messages.invalid_params')));
+      }
+
+      if (!req.reqId || !this[_decodeReqPool][req.reqId]) {
+        return reject(new Error(i18n.__('messages.invalid_req')));
+      }
+
+      const authReq = types.allocAuthReq(
+        typeConstructor.constructAuthReq(this[_decodeReqPool][req.reqId])
+      );
+
+      delete this[_decodeReqPool][req.reqId];
+
+      try {
+        const authDecisionCb = this._pushCb(
+          ffi.Callback(
+            types.Void,
+            [types.voidPointer, types.FfiResultPointer, types.CString],
+            (userData, resultPtr, res) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0) {
+                return reject(JSON.stringify(result));
+              }
+
+              logger.info(
+                'authenticator.js: auth decision CB',
+                result,
+                isAllowed
+              );
+
+              if (isAllowed) {
+                this._updateAppList();
+              }
+              const appUri = genAppUri(req.authReq.app.id);
+              resolve(`${appUri}:${res}`);
             }
-        } );
-    }
+          )
+        );
+        this.safeLib.encode_auth_resp(
+          this.registeredClientHandle,
+          authReq,
+          req.reqId,
+          isAllowed,
+          types.Null,
+          this._getCb(authDecisionCb)
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
 
-    _isAlreadyAuthorisedContainer( request ) {
-        const req = lodash.cloneDeep( request );
-        let app = null;
-        return new Promise( ( resolve, reject ) => {
-            try {
-                this.getRegisteredApps().then( authorisedApps => {
-                    app = authorisedApps.filter( apps =>
-                        lodash.isEqual( apps.app_info, req.app )
-                    );
-                    // Return false if no apps found match with requested app
-                    if ( app.length === 0 ) {
-                        return resolve( false );
-                    }
-                    app = app[0];
-                    let i;
-                    for ( i = 0; i < req.containers.length; i++ ) {
-                        if ( lodash.findIndex( app.containers, req.containers[i] ) === -1 ) {
-                            resolve( false );
-                            break;
-                        }
-                    }
-                    return resolve( true );
-                } );
-            } catch ( err ) {
-                return reject( err );
+  encodeContainersResp(req, isAllowed) {
+    return new Promise((resolve, reject) => {
+      if (!this.registeredClientHandle) {
+        return reject(new Error(i18n.__('messages.unauthorised')));
+      }
+
+      if (!req || typeof isAllowed !== 'boolean') {
+        return reject(new Error(i18n.__('messages.invalid_params')));
+      }
+
+      if (!req.reqId || !this[_decodeReqPool][req.reqId]) {
+        return reject(new Error(i18n.__('messages.invalid_req')));
+      }
+      const contReq = types.allocContainerReq(
+        typeConstructor.constructContainerReq(this[_decodeReqPool][req.reqId])
+      );
+
+      delete this[_decodeReqPool][req.reqId];
+
+      try {
+        const contDecisionCb = this._pushCb(
+          ffi.Callback(
+            types.Void,
+            [types.voidPointer, types.FfiResultPointer, types.CString],
+            (userData, resultPtr, res) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0) {
+                return reject(JSON.stringify(result));
+              }
+              if (isAllowed) {
+                this._updateAppList();
+              }
+              const appUri = genAppUri(req.contReq.app.id);
+              resolve(`${appUri}:${res}`);
             }
-        } );
+          )
+        );
+
+        this.safeLib.encode_containers_resp(
+          this.registeredClientHandle,
+          contReq,
+          req.reqId,
+          isAllowed,
+          types.Null,
+          this._getCb(contDecisionCb)
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  encodeMDataResp(req, isAllowed) {
+    console.log('asdadad');
+    logger.info('doing this', req, isAllowed);
+    return new Promise((resolve, reject) => {
+      if (!this.registeredClientHandle) {
+        return reject(new Error(i18n.__('messages.unauthorised')));
+      }
+
+      if (!req || typeof isAllowed !== 'boolean') {
+        return reject(new Error(i18n.__('messages.invalid_params')));
+      }
+
+      if (!req.reqId || !this[_decodeReqPool][req.reqId]) {
+        return reject(new Error(i18n.__('messages.invalid_req')));
+      }
+
+      const mDataReq = types.allocSharedMdataReq(
+        typeConstructor.constructSharedMdataReq(this[_decodeReqPool][req.reqId])
+      );
+
+      delete this[_decodeReqPool][req.reqId];
+
+      try {
+        const mDataDecisionCb = this._pushCb(
+          ffi.Callback(
+            types.Void,
+            [types.voidPointer, types.FfiResultPointer, types.CString],
+            (userData, resultPtr, res) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0) {
+                return reject(JSON.stringify(result));
+              }
+              if (isAllowed) {
+                this._updateAppList();
+              }
+              const appUri = genAppUri(req.mDataReq.app.id);
+              resolve(`${appUri}:${res}`);
+            }
+          )
+        );
+
+        this.safeLib.encode_share_mdata_resp(
+          this.registeredClientHandle,
+          mDataReq,
+          req.reqId,
+          isAllowed,
+          types.Null,
+          this._getCb(mDataDecisionCb)
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  revokeApp(appId) {
+    return new Promise((resolve, reject) => {
+      if (!this.registeredClientHandle) {
+        return reject(new Error(i18n.__('messages.unauthorised')));
+      }
+
+      if (!appId) {
+        return reject(
+          new Error(i18n.__('messages.should_not_be_empty', i18n.__('AppId')))
+        );
+      }
+
+      if (typeof appId !== 'string') {
+        return reject(
+          new Error(i18n.__('messages.must_be_string', i18n.__('AppId')))
+        );
+      }
+
+      if (!appId.trim()) {
+        return reject(
+          new Error(i18n.__('messages.should_not_be_empty', i18n.__('AppId')))
+        );
+      }
+
+      try {
+        const revokeCb = this._pushCb(
+          ffi.Callback(
+            types.Void,
+            [types.voidPointer, types.FfiResultPointer, types.CString],
+            (userData, resultPtr, res) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0) {
+                return reject(JSON.stringify(result));
+              }
+              this._updateAppList();
+              resolve(res);
+            }
+          )
+        );
+
+        this.safeLib.auth_revoke_app(
+          this.registeredClientHandle,
+          types.allocCString(appId),
+          types.Null,
+          this._getCb(revokeCb)
+        );
+      } catch (e) {
+        reject(e.message);
+      }
+    });
+  }
+
+  getRegisteredApps() {
+    return new Promise((resolve, reject) => {
+      if (!this.registeredClientHandle) {
+        return reject(new Error(i18n.__('messages.unauthorised')));
+      }
+      let cb = null;
+      cb = this._pushCb(
+        ffi.Callback(
+          types.Void,
+          [
+            types.voidPointer,
+            types.FfiResultPointer,
+            types.RegisteredAppPointer,
+            types.usize
+          ],
+          (userData, resultPtr, appList, len) => {
+            const result = resultPtr.deref();
+            this._deleteFromCb(cb);
+            if (result.error_code !== 0) {
+              return reject(JSON.stringify(result));
+            }
+            const apps = typeParser.parseRegisteredAppArray(appList, len);
+            resolve(apps);
+          }
+        )
+      );
+
+      try {
+        this.safeLib.auth_registered_apps(
+          this.registeredClientHandle,
+          types.Null,
+          this._getCb(cb)
+        );
+      } catch (e) {
+        reject(e.message);
+      }
+    });
+  }
+
+  getAccountInfo() {
+    return new Promise((resolve, reject) => {
+      if (!this.registeredClientHandle) {
+        return reject(new Error(i18n.__('messages.unauthorised')));
+      }
+      const cb = this._pushCb(
+        ffi.Callback(
+          types.Void,
+          [types.voidPointer, types.FfiResultPointer, types.AccountInfoPointer],
+          (userData, resultPtr, accInfo) => {
+            const result = resultPtr.deref();
+            if (result.error_code !== 0) {
+              return reject(JSON.stringify(result));
+            }
+            const info = accInfo.deref();
+            resolve({
+              done: info.mutations_done,
+              available: info.mutations_available
+            });
+          }
+        )
+      );
+
+      try {
+        this.safeLib.auth_account_info(
+          this.registeredClientHandle,
+          types.Null,
+          this._getCb(cb)
+        );
+      } catch (e) {
+        reject(e.message);
+      }
+    });
+  }
+
+  _appsAccessingMData(name, typeTag) {
+    const nameBuf = types.XorName(Buffer.from(name, 'hex')).buffer;
+    return new Promise((resolve, reject) => {
+      if (!this.registeredClientHandle) {
+        return reject(new Error(i18n.__('messages.unauthorised')));
+      }
+      const cb = this._pushCb(
+        ffi.Callback(
+          types.Void,
+          [
+            types.voidPointer,
+            types.FfiResultPointer,
+            types.AppAccessPointer,
+            types.usize
+          ],
+          (userData, resultPtr, appAccess, len) => {
+            const result = resultPtr.deref();
+            if (result.error_code !== 0) {
+              return reject(JSON.stringify(result));
+            }
+            const appAccessInfo = typeParser.parseAppAccess(appAccess, len);
+            return resolve(appAccessInfo);
+          }
+        )
+      );
+
+      try {
+        this.safeLib.auth_apps_accessing_mutable_data(
+          this.registeredClientHandle,
+          nameBuf,
+          typeTag,
+          types.Null,
+          this._getCb(cb)
+        );
+      } catch (e) {
+        reject(e.message);
+      }
+    });
+  }
+
+  _pushCb(cb) {
+    const rand = crypto.randomBytes(32).toString('hex');
+    this[_cbRegistry][rand] = cb;
+    return rand;
+  }
+
+  _getCb(rand) {
+    return this[_cbRegistry][rand];
+  }
+
+  _deleteFromCb(rand) {
+    if (!this[_cbRegistry][rand]) {
+      return;
+    }
+    delete this[_cbRegistry][rand];
+  }
+
+  _updateAppList() {
+    this.getRegisteredApps().then((apps) => {
+      if (
+        this[_appListUpdateListener] &&
+        this[_appListUpdateListener].len() !== 0
+      ) {
+        this[_appListUpdateListener].broadcast(null, apps);
+      }
+    });
+  }
+
+  _decodeUnRegisteredRequest(parsedUri, resolve, reject) {
+    if (!parsedUri) {
+      return reject(new Error(errConst.INVALID_URI.msg));
     }
 
-    /**
+    const unregisteredCb = this._getUnregisteredClientCb(resolve, reject);
+
+    const decodeReqErrorCb = this._pushCb(
+      ffi.Callback(
+        types.Void,
+        [types.voidPointer, types.FfiResultPointer, types.CString],
+        () => {
+          reject(new Error(errConst.UNAUTHORISED.msg));
+        }
+      )
+    );
+
+    try {
+      this.safeLib.auth_unregistered_decode_ipc_msg(
+        types.allocCString(parsedUri),
+        types.Null,
+        this._getCb(unregisteredCb),
+        this._getCb(decodeReqErrorCb)
+      );
+    } catch (err) {
+      return reject(err);
+    }
+  }
+
+  _encodeUnRegisteredResp(reqId, appId) {
+    return new Promise((resolve, reject) => {
+      try {
+        const encodeCb = this._pushCb(
+          ffi.Callback(
+            types.Void,
+            [types.voidPointer, types.FfiResultPointer, types.CString],
+            (userData, resultPtr, res) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0 && !res) {
+                return reject(JSON.stringify(result));
+              }
+              const appUri = genAppUri(appId);
+              resolve(`${appUri}:${res}`);
+            }
+          )
+        );
+        this.safeLib.encode_unregistered_resp(
+          reqId,
+          true,
+          types.Null,
+          this._getCb(encodeCb)
+        );
+      } catch (e) {
+        reject(e.message);
+      }
+    });
+  }
+
+  _getUnregisteredClientCb(resolve, reject) {
+    return this._pushCb(
+      ffi.Callback(
+        types.Void,
+        [types.voidPointer, types.u32, types.u8Pointer, types.usize],
+        (userData, reqId, appIdPtr, appIdLen) => {
+          if (!reqId || appIdLen <= 0) {
+            return reject(new Error(errConst, INVALID_RESPONSE.msg));
+          }
+
+          const appId = ref.reinterpret(appIdPtr, appIdLen);
+          return this._encodeUnRegisteredResp(reqId, appId).then((res) =>
+            resolve(res)
+          );
+        }
+      )
+    );
+  }
+
+  _isAlreadyAuthorised(request) {
+    const req = lodash.cloneDeep(request);
+    return new Promise((resolve, reject) => {
+      try {
+        this.getRegisteredApps()
+          .then((authorisedApps) => {
+            let previouslyAuthorisedContainers;
+            const isAuthorised = authorisedApps.some((app) => {
+              const appIsPresent = lodash.isEqual(app.app_info, req.app);
+              if (appIsPresent && app.containers) {
+                previouslyAuthorisedContainers = app.containers;
+              }
+              return appIsPresent;
+            });
+            return {
+              isAuthorised,
+              previouslyAuthorisedContainers
+            };
+          })
+          .then(resolve);
+      } catch (err) {
+        return reject(err);
+      }
+    });
+  }
+
+  _isAlreadyAuthorisedContainer(request) {
+    const req = lodash.cloneDeep(request);
+    let app = null;
+    return new Promise((resolve, reject) => {
+      try {
+        this.getRegisteredApps().then((authorisedApps) => {
+          app = authorisedApps.filter((apps) =>
+            lodash.isEqual(apps.app_info, req.app)
+          );
+          // Return false if no apps found match with requested app
+          if (app.length === 0) {
+            return resolve(false);
+          }
+          app = app[0];
+          let i;
+          for (i = 0; i < req.containers.length; i++) {
+            if (lodash.findIndex(app.containers, req.containers[i]) === -1) {
+              resolve(false);
+              break;
+            }
+          }
+          return resolve(true);
+        });
+      } catch (err) {
+        return reject(err);
+      }
+    });
+  }
+
+  /**
    * Push network state to registered listeners
    * @param state
    * @private
    */
-    _pushNetworkState( state ) {
-        let networkState = state;
-        if ( typeof networkState === 'undefined' ) {
-            networkState = this.networkState;
-        }
-
-        this.networkState = networkState;
-
-        if (
-            this[_nwStateChangeListener] &&
-      this[_nwStateChangeListener].len() !== 0
-        ) {
-            this[_nwStateChangeListener].broadcast( null, this.networkState );
-        }
+  _pushNetworkState(state) {
+    let networkState = state;
+    if (typeof networkState === 'undefined') {
+      networkState = this.networkState;
     }
 
-    /**
+    this.networkState = networkState;
+
+    if (
+      this[_nwStateChangeListener] &&
+      this[_nwStateChangeListener].len() !== 0
+    ) {
+      this[_nwStateChangeListener].broadcast(null, this.networkState);
+    }
+  }
+
+  /**
    * Validate user credential - locator and secret
    * @param locator
    * @param secret
    * @returns {Error}
    * @private
    */
-    /* eslint-disable class-methods-use-this */
-    _isUserCredentialsValid( locator, secret ) {
+  /* eslint-disable class-methods-use-this */
+  _isUserCredentialsValid(locator, secret) {
     /* eslint-enable class-methods-use-this */
-        if ( !locator ) {
-            return new Error(
-                i18n.__( 'messages.should_not_be_empty', i18n.__( 'Locator' ) )
-            );
-        }
-
-        if ( !secret ) {
-            return new Error(
-                i18n.__( 'messages.should_not_be_empty', i18n.__( 'Secret' ) )
-            );
-        }
-
-        if ( typeof locator !== 'string' ) {
-            return new Error( i18n.__( 'messages.must_be_string', i18n.__( 'Locator' ) ) );
-        }
-
-        if ( typeof secret !== 'string' ) {
-            return new Error( i18n.__( 'messages.must_be_string', i18n.__( 'Secret' ) ) );
-        }
-        if ( !locator.trim() ) {
-            return new Error(
-                i18n.__( 'messages.should_not_be_empty', i18n.__( 'Locator' ) )
-            );
-        }
-
-        if ( !secret.trim() ) {
-            return new Error(
-                i18n.__( 'messages.should_not_be_empty', i18n.__( 'Secret' ) )
-            );
-        }
+    if (!locator) {
+      return new Error(
+        i18n.__('messages.should_not_be_empty', i18n.__('Locator'))
+      );
     }
+
+    if (!secret) {
+      return new Error(
+        i18n.__('messages.should_not_be_empty', i18n.__('Secret'))
+      );
+    }
+
+    if (typeof locator !== 'string') {
+      return new Error(i18n.__('messages.must_be_string', i18n.__('Locator')));
+    }
+
+    if (typeof secret !== 'string') {
+      return new Error(i18n.__('messages.must_be_string', i18n.__('Secret')));
+    }
+    if (!locator.trim()) {
+      return new Error(
+        i18n.__('messages.should_not_be_empty', i18n.__('Locator'))
+      );
+    }
+
+    if (!secret.trim()) {
+      return new Error(
+        i18n.__('messages.should_not_be_empty', i18n.__('Secret'))
+      );
+    }
+  }
 }
 
 const authenticator = new Authenticator();

--- a/app/extensions/safe/ffi/lib.ts
+++ b/app/extensions/safe/ffi/lib.ts
@@ -12,121 +12,121 @@ import authenticator from './authenticator';
 import * as types from './refs/types';
 import { CONSTANTS } from '../auth-constants';
 
-const _mods = Symbol( '_mods' );
-const _libPath = Symbol( '_libPath' );
+const _mods = Symbol('_mods');
+const _libPath = Symbol('_libPath');
 
 class LibLoader {
-    constructor() {
-        this[_mods] = [authenticator];
-        this[_libPath] = CONSTANTS.LIB_PATH.SAFE_AUTH[os.platform()];
+  constructor() {
+    this[_mods] = [authenticator];
+    this[_libPath] = CONSTANTS.LIB_PATH.SAFE_AUTH[os.platform()];
+  }
+
+  load(isMock = false) {
+    if (isMock) {
+      this[_libPath] = CONSTANTS.LIB_PATH_MOCK.SAFE_AUTH[os.platform()];
     }
 
-    load( isMock = false ) {
-        if ( isMock ) {
-            this[_libPath] = CONSTANTS.LIB_PATH_MOCK.SAFE_AUTH[os.platform()];
-        }
+    logger.info('Auth lib location loading: ', this[_libPath]);
 
-        logger.info( 'Auth lib location loading: ', this[_libPath] );
+    const safeLib = {};
+    const { RTLD_NOW } = ffi.DynamicLibrary.FLAGS;
+    const { RTLD_GLOBAL } = ffi.DynamicLibrary.FLAGS;
+    const mode = RTLD_NOW || RTLD_GLOBAL;
 
-        const safeLib = {};
-        const { RTLD_NOW } = ffi.DynamicLibrary.FLAGS;
-        const { RTLD_GLOBAL } = ffi.DynamicLibrary.FLAGS;
-        const mode = RTLD_NOW || RTLD_GLOBAL;
+    let ffiFunctions = {};
+    let fnsToRegister;
+    let fnDefinition;
 
-        let ffiFunctions = {};
-        let fnsToRegister;
-        let fnDefinition;
+    // Load all modules
+    this[_mods].forEach((mod) => {
+      if (!(mod instanceof SafeLib)) {
+        return;
+      }
+      fnsToRegister = mod.fnsToRegister();
+      if (!fnsToRegister) {
+        return;
+      }
+      ffiFunctions = Object.assign({}, ffiFunctions, fnsToRegister);
+    });
 
-        // Load all modules
-        this[_mods].forEach( mod => {
-            if ( !( mod instanceof SafeLib ) ) {
-                return;
-            }
-            fnsToRegister = mod.fnsToRegister();
-            if ( !fnsToRegister ) {
-                return;
-            }
-            ffiFunctions = Object.assign( {}, ffiFunctions, fnsToRegister );
-        } );
+    return new Promise((resolve, reject) => {
+      try {
+        const lib = ffi.DynamicLibrary(
+          path.resolve(__dirname, this[_libPath]),
+          mode
+        );
 
-        return new Promise( ( resolve, reject ) => {
-            try {
-                const lib = ffi.DynamicLibrary(
-                    path.resolve( __dirname, this[_libPath] ),
-                    mode
-                );
+        Object.keys(ffiFunctions).forEach((fnName) => {
+          fnDefinition = ffiFunctions[fnName];
+          safeLib[fnName] = ffi.ForeignFunction(
+            lib.get(fnName),
+            fnDefinition[0],
+            fnDefinition[1]
+          );
+        });
+        this[_mods].forEach((mod) => {
+          if (!(mod instanceof SafeLib)) {
+            return;
+          }
+          mod.isLibLoaded = true;
+          mod.safeLib = safeLib;
+        });
 
-                Object.keys( ffiFunctions ).forEach( fnName => {
-                    fnDefinition = ffiFunctions[fnName];
-                    safeLib[fnName] = ffi.ForeignFunction(
-                        lib.get( fnName ),
-                        fnDefinition[0],
-                        fnDefinition[1]
-                    );
-                } );
-                this[_mods].forEach( mod => {
-                    if ( !( mod instanceof SafeLib ) ) {
-                        return;
-                    }
-                    mod.isLibLoaded = true;
-                    mod.safeLib = safeLib;
-                } );
-
-                const setConfigSearchPath = () => {
-                    if (
-                        process.env.SAFE_CONFIG_PATH &&
+        const setConfigSearchPath = () => {
+          if (
+            process.env.SAFE_CONFIG_PATH &&
             process.env.SAFE_CONFIG_PATH.length > 0
-                    ) {
-                        const configPath = types.allocCString( process.env.SAFE_CONFIG_PATH );
+          ) {
+            const configPath = types.allocCString(process.env.SAFE_CONFIG_PATH);
 
-                        safeLib.auth_set_additional_search_path(
-                            configPath,
-                            types.Null,
-                            ffi.Callback(
-                                types.Void,
-                                [types.voidPointer, types.FfiResultPointer],
-                                ( userData, resultPtr ) => {
-                                    const result = resultPtr.deref();
-                                    if ( result.error_code !== 0 ) {
-                                        return reject( JSON.stringify( result ) );
-                                    }
-                                    resolve();
-                                }
-                            )
-                        );
-                    } else {
-                        resolve();
-                    }
-                };
+            safeLib.auth_set_additional_search_path(
+              configPath,
+              types.Null,
+              ffi.Callback(
+                types.Void,
+                [types.voidPointer, types.FfiResultPointer],
+                (userData, resultPtr) => {
+                  const result = resultPtr.deref();
+                  if (result.error_code !== 0) {
+                    return reject(JSON.stringify(result));
+                  }
+                  resolve();
+                }
+              )
+            );
+          } else {
+            resolve();
+          }
+        };
 
-                // init logging
-                safeLib.auth_init_logging(
-                    types.allocCString( 'authenticator.log' ),
-                    types.Null,
-                    ffi.Callback(
-                        types.Void,
-                        [types.voidPointer, types.FfiResultPointer],
-                        ( userData, resultPtr ) => {
-                            const result = resultPtr.deref();
-                            if ( result.error_code !== 0 ) {
-                                return reject( JSON.stringify( result ) );
-                            }
+        // init logging
+        safeLib.auth_init_logging(
+          types.allocCString('authenticator.log'),
+          types.Null,
+          ffi.Callback(
+            types.Void,
+            [types.voidPointer, types.FfiResultPointer],
+            (userData, resultPtr) => {
+              const result = resultPtr.deref();
+              if (result.error_code !== 0) {
+                return reject(JSON.stringify(result));
+              }
 
-                            setConfigSearchPath();
-                        }
-                    )
-                );
-            } catch ( err ) {
-                this[_mods].forEach( mod => {
-                    if ( !( mod instanceof SafeLib ) ) {
-                        return;
-                    }
-                    mod.isLibLoaded = false;
-                } );
-                return reject( err );
+              setConfigSearchPath();
             }
-        } );
-    }
+          )
+        );
+      } catch (err) {
+        this[_mods].forEach((mod) => {
+          if (!(mod instanceof SafeLib)) {
+            return;
+          }
+          mod.isLibLoaded = false;
+        });
+        return reject(err);
+      }
+    });
+  }
 }
 
 const libLoader = new LibLoader();

--- a/app/extensions/safe/ffi/listeners.ts
+++ b/app/extensions/safe/ffi/listeners.ts
@@ -1,49 +1,49 @@
 /* eslint-disable no-underscore-dangle */
 import crypto from 'crypto';
 
-const _cbFunctions = Symbol( '_cbFunctions' );
+const _cbFunctions = Symbol('_cbFunctions');
 
 export default class Listener {
-    constructor() {
-        this[_cbFunctions] = {};
-    }
+  constructor() {
+    this[_cbFunctions] = {};
+  }
 
-    add( cb ) {
-        if ( typeof cb !== 'function' ) {
-            return;
-        }
-        const rand = crypto.randomBytes( 32 ).toString( 'hex' );
-        this[_cbFunctions][rand] = cb;
-        return rand;
+  add(cb) {
+    if (typeof cb !== 'function') {
+      return;
     }
+    const rand = crypto.randomBytes(32).toString('hex');
+    this[_cbFunctions][rand] = cb;
+    return rand;
+  }
 
-    len() {
-        return Object.keys( this[_cbFunctions] );
-    }
+  len() {
+    return Object.keys(this[_cbFunctions]);
+  }
 
-    remove( id ) {
-        if ( !id ) {
-            return;
-        }
-        delete this[_cbFunctions][id];
+  remove(id) {
+    if (!id) {
+      return;
     }
+    delete this[_cbFunctions][id];
+  }
 
-    push( cbId, err, data ) {
-        if ( !this[_cbFunctions].hasOwnProperty( cbId ) ) {
-            return;
-        }
-        this[_cbFunctions][cbId].call( this, err, data );
+  push(cbId, err, data) {
+    if (!this[_cbFunctions].hasOwnProperty(cbId)) {
+      return;
     }
+    this[_cbFunctions][cbId].call(this, err, data);
+  }
 
-    broadcast( err, data ) {
-        Object.keys( this[_cbFunctions] ).forEach( id => {
-            try {
-                this[_cbFunctions][id].call( this[_cbFunctions][id], err, data );
-            } catch ( e ) {
-                // remove the callback if object destroyed
-                console.warn( 'Listener warn :', e.message );
-                this.remove( id );
-            }
-        } );
-    }
+  broadcast(err, data) {
+    Object.keys(this[_cbFunctions]).forEach((id) => {
+      try {
+        this[_cbFunctions][id].call(this[_cbFunctions][id], err, data);
+      } catch (e) {
+        // remove the callback if object destroyed
+        console.warn('Listener warn :', e.message);
+        this.remove(id);
+      }
+    });
+  }
 }

--- a/app/extensions/safe/ffi/refs/parsers.ts
+++ b/app/extensions/safe/ffi/refs/parsers.ts
@@ -2,159 +2,159 @@ import ref from 'ref';
 import ArrayType from 'ref-array';
 import * as types from './types';
 
-export const parseArray = ( type, arrayBuf, len ) => {
-    if ( len === 0 ) {
-        return [];
-    }
-    const arrPtr = ref.reinterpret( arrayBuf, type.size * len );
-    const ArrType = ArrayType( type );
-    return ArrType( arrPtr );
+export const parseArray = (type, arrayBuf, len) => {
+  if (len === 0) {
+    return [];
+  }
+  const arrPtr = ref.reinterpret(arrayBuf, type.size * len);
+  const ArrType = ArrayType(type);
+  return ArrType(arrPtr);
 };
 
-export const parseAppExchangeInfo = appExchangeInfo => ( {
-    id: appExchangeInfo.id,
-    scope: appExchangeInfo.scope,
-    name: appExchangeInfo.name,
-    vendor: appExchangeInfo.vendor
-} );
+export const parseAppExchangeInfo = (appExchangeInfo) => ({
+  id: appExchangeInfo.id,
+  scope: appExchangeInfo.scope,
+  name: appExchangeInfo.name,
+  vendor: appExchangeInfo.vendor
+});
 
-const parsePermissionSet = perms => ( {
-    read: perms.read,
-    insert: perms.insert,
-    update: perms.update,
-    delete: perms.delete,
-    manage_permissions: perms.manage_permissions
-} );
+const parsePermissionSet = (perms) => ({
+  read: perms.read,
+  insert: perms.insert,
+  update: perms.update,
+  delete: perms.delete,
+  manage_permissions: perms.manage_permissions
+});
 
-export const parseContainerPermissions = containerPermissions => ( {
-    cont_name: containerPermissions.cont_name,
-    access: parsePermissionSet( containerPermissions.access )
-} );
+export const parseContainerPermissions = (containerPermissions) => ({
+  cont_name: containerPermissions.cont_name,
+  access: parsePermissionSet(containerPermissions.access)
+});
 
 export const parseContainerPermissionsArray = (
+  containerPermissionsArray,
+  len
+) => {
+  const res = [];
+  let i = 0;
+  const contArr = parseArray(
+    types.ContainerPermissions,
     containerPermissionsArray,
     len
-) => {
-    const res = [];
-    let i = 0;
-    const contArr = parseArray(
-        types.ContainerPermissions,
-        containerPermissionsArray,
-        len
-    );
-    for ( i = 0; i < contArr.length; i++ ) {
-        res.push( parseContainerPermissions( contArr[i] ) );
-    }
-    return res;
+  );
+  for (i = 0; i < contArr.length; i++) {
+    res.push(parseContainerPermissions(contArr[i]));
+  }
+  return res;
 };
 
-export const parseRegisteredApp = registeredApp => ( {
-    app_info: parseAppExchangeInfo( registeredApp.app_info ),
-    containers: parseContainerPermissionsArray(
-        registeredApp.containers,
-        registeredApp.containers_len
-    ),
-    containers_len: registeredApp.containers_len,
-    containers_cap: registeredApp.containers_cap
-} );
+export const parseRegisteredApp = (registeredApp) => ({
+  app_info: parseAppExchangeInfo(registeredApp.app_info),
+  containers: parseContainerPermissionsArray(
+    registeredApp.containers,
+    registeredApp.containers_len
+  ),
+  containers_len: registeredApp.containers_len,
+  containers_cap: registeredApp.containers_cap
+});
 
-export const parseRegisteredAppArray = ( registeredAppArray, len ) => {
-    const res = [];
-    let i = 0;
-    const registeredApps = parseArray(
-        types.RegisteredApp,
-        registeredAppArray,
-        len
-    );
-    for ( i = 0; i < registeredApps.length; i++ ) {
-        res.push( parseRegisteredApp( registeredApps[i] ) );
-    }
-    return res;
+export const parseRegisteredAppArray = (registeredAppArray, len) => {
+  const res = [];
+  let i = 0;
+  const registeredApps = parseArray(
+    types.RegisteredApp,
+    registeredAppArray,
+    len
+  );
+  for (i = 0; i < registeredApps.length; i++) {
+    res.push(parseRegisteredApp(registeredApps[i]));
+  }
+  return res;
 };
 
-export const parseAuthReq = authReq => ( {
-    app: parseAppExchangeInfo( authReq.app ),
-    app_container: authReq.app_container,
-    containers: parseContainerPermissionsArray(
-        authReq.containers,
-        authReq.containers_len
-    ),
-    containers_len: authReq.containers_len,
-    containers_cap: authReq.containers_cap
-} );
+export const parseAuthReq = (authReq) => ({
+  app: parseAppExchangeInfo(authReq.app),
+  app_container: authReq.app_container,
+  containers: parseContainerPermissionsArray(
+    authReq.containers,
+    authReq.containers_len
+  ),
+  containers_len: authReq.containers_len,
+  containers_cap: authReq.containers_cap
+});
 
-export const parseContainerReq = containersReq => ( {
-    app: parseAppExchangeInfo( containersReq.app ),
-    containers: parseContainerPermissionsArray(
-        containersReq.containers,
-        containersReq.containers_len
-    ),
-    containers_len: containersReq.containers_len,
-    containers_cap: containersReq.containers_cap
-} );
+export const parseContainerReq = (containersReq) => ({
+  app: parseAppExchangeInfo(containersReq.app),
+  containers: parseContainerPermissionsArray(
+    containersReq.containers,
+    containersReq.containers_len
+  ),
+  containers_len: containersReq.containers_len,
+  containers_cap: containersReq.containers_cap
+});
 
-const parseXorName = str => {
-    const b = new Buffer( str );
-    if ( b.length !== 32 ) throw Error( 'XOR Names _must be_ 32 bytes long.' );
-    const name = types.XorName( b );
-    return new Buffer( name ).toString( 'hex' );
+const parseXorName = (str) => {
+  const b = new Buffer(str);
+  if (b.length !== 32) throw Error('XOR Names _must be_ 32 bytes long.');
+  const name = types.XorName(b);
+  return new Buffer(name).toString('hex');
 };
 
-const parseShareMData = shareMData => ( {
-    type_tag: shareMData.type_tag,
-    name: parseXorName( shareMData.name ),
-    perms: parsePermissionSet( shareMData.perms )
-} );
+const parseShareMData = (shareMData) => ({
+  type_tag: shareMData.type_tag,
+  name: parseXorName(shareMData.name),
+  perms: parsePermissionSet(shareMData.perms)
+});
 
-const parseSharedMDataArray = ( shareMData, len ) => {
-    const res = [];
-    let i = 0;
-    const mdatas = parseArray( types.ShareMData, shareMData, len );
-    for ( i = 0; i < mdatas.length; i++ ) {
-        res.push( parseShareMData( mdatas[i] ) );
-    }
-    return res;
+const parseSharedMDataArray = (shareMData, len) => {
+  const res = [];
+  let i = 0;
+  const mdatas = parseArray(types.ShareMData, shareMData, len);
+  for (i = 0; i < mdatas.length; i++) {
+    res.push(parseShareMData(mdatas[i]));
+  }
+  return res;
 };
 
-export const parseShareMDataReq = shareMDataReq => ( {
-    app: parseAppExchangeInfo( shareMDataReq.app ),
-    mdata: parseSharedMDataArray( shareMDataReq.mdata, shareMDataReq.mdata_len ),
-    mdata_len: shareMDataReq.mdata_len
-} );
+export const parseShareMDataReq = (shareMDataReq) => ({
+  app: parseAppExchangeInfo(shareMDataReq.app),
+  mdata: parseSharedMDataArray(shareMDataReq.mdata, shareMDataReq.mdata_len),
+  mdata_len: shareMDataReq.mdata_len
+});
 
-const parseUserMetaData = meta => ( {
-    name: meta.name,
-    description: meta.description
-} );
+const parseUserMetaData = (meta) => ({
+  name: meta.name,
+  description: meta.description
+});
 
-export const parseUserMetaDataArray = ( metaArr, len ) => {
-    const res = [];
-    let i = 0;
-    const metaData = parseArray( types.UserMetadata, metaArr, len );
-    for ( i = 0; i < metaData.length; i++ ) {
-        res.push( parseUserMetaData( metaData[i] ) );
-    }
-    return res;
+export const parseUserMetaDataArray = (metaArr, len) => {
+  const res = [];
+  let i = 0;
+  const metaData = parseArray(types.UserMetadata, metaArr, len);
+  for (i = 0; i < metaData.length; i++) {
+    res.push(parseUserMetaData(metaData[i]));
+  }
+  return res;
 };
 
-const parseAppAccessInfo = appAccess => {
-    let signKey = types.U8Array( new Buffer( appAccess.sign_key ) );
-    signKey = new Buffer( signKey ).toString( 'hex' );
-    return {
-        sign_key: signKey,
-        permissions: parsePermissionSet( appAccess.permissions ),
-        app: appAccess.name
+const parseAppAccessInfo = (appAccess) => {
+  let signKey = types.U8Array(new Buffer(appAccess.sign_key));
+  signKey = new Buffer(signKey).toString('hex');
+  return {
+    sign_key: signKey,
+    permissions: parsePermissionSet(appAccess.permissions),
+    app: appAccess.name
     // TODO: Why does uncommenting the following line break shareMData requests?
     // app_id: appAccess.app_id
-    };
+  };
 };
 
-export const parseAppAccess = ( appAccess, len ) => {
-    const res = [];
-    let i = 0;
-    const info = parseArray( types.AppAccess, appAccess, len );
-    for ( i = 0; i < info.length; i++ ) {
-        res.push( parseAppAccessInfo( info[i] ) );
-    }
-    return res;
+export const parseAppAccess = (appAccess, len) => {
+  const res = [];
+  let i = 0;
+  const info = parseArray(types.AppAccess, appAccess, len);
+  for (i = 0; i < info.length; i++) {
+    res.push(parseAppAccessInfo(info[i]));
+  }
+  return res;
 };

--- a/app/extensions/safe/ffi/safe_lib.ts
+++ b/app/extensions/safe/ffi/safe_lib.ts
@@ -3,37 +3,37 @@
  */
 /* eslint-disable no-underscore-dangle */
 // Private variables
-const _safeLib = Symbol( 'safeLib' );
-const _isLibraryLoaded = Symbol( 'isLibraryLoaded' );
+const _safeLib = Symbol('safeLib');
+const _isLibraryLoaded = Symbol('isLibraryLoaded');
 
 export default class SafeLib {
-    constructor() {
-        this[_safeLib] = null;
-        this[_isLibraryLoaded] = false;
-    }
+  constructor() {
+    this[_safeLib] = null;
+    this[_isLibraryLoaded] = false;
+  }
 
-    set safeLib( lib ) {
-        this[_safeLib] = lib;
-    }
+  set safeLib(lib) {
+    this[_safeLib] = lib;
+  }
 
-    get safeLib() {
-        return this[_safeLib];
-    }
+  get safeLib() {
+    return this[_safeLib];
+  }
 
-    set isLibLoaded( status ) {
-        this[_isLibraryLoaded] = !!status;
-    }
+  set isLibLoaded(status) {
+    this[_isLibraryLoaded] = !!status;
+  }
 
-    get isLibLoaded() {
-        return this[_isLibraryLoaded];
-    }
+  get isLibLoaded() {
+    return this[_isLibraryLoaded];
+  }
 
-    // Abstract methods
-    /* eslint-disable class-methods-use-this */
-    /* eslint-disable no-unused-vars */
-    drop( safeLib ) {}
+  // Abstract methods
+  /* eslint-disable class-methods-use-this */
+  /* eslint-disable no-unused-vars */
+  drop(safeLib) {}
 
-    /* eslint-enable no-unused-vars */
-    fnsToRegister() {}
-    /* eslint-enable class-methods-use-this */
+  /* eslint-enable no-unused-vars */
+  fnsToRegister() {}
+  /* eslint-enable class-methods-use-this */
 }

--- a/app/extensions/safe/safeBrowserApplication/manageBrowserConfig.ts
+++ b/app/extensions/safe/safeBrowserApplication/manageBrowserConfig.ts
@@ -1,14 +1,10 @@
 import { logger } from '$Logger';
 import {
-    setSaveConfigStatus,
-    setReadConfigStatus
-} from '$Extensions/safe/actions/safeBrowserApplication_actions';
-
-import {
     safeBrowserAppIsAuthing,
     safeBrowserAppIsAuthed,
     safeBrowserAppIsConnected,
-    safeBrowserAppAuthFailed
+    safeBrowserAppAuthFailed,
+    getSafeBrowserAppObject
 } from '$Extensions/safe/safeBrowserApplication/theApplication';
 
 import { addNotification } from '$Actions/notification_actions';
@@ -18,162 +14,17 @@ import { SAFE, SAFE_APP_ERROR_CODES } from '$Extensions/safe/constants';
 import * as safeBrowserAppActions from '$Extensions/safe/actions/safeBrowserApplication_actions';
 import * as bookmarksActions from '$Actions/bookmarks_actions';
 import * as tabsActions from '$Actions/tabs_actions';
-import { getSafeBrowserAppObject } from './theApplication';
 
 // TODO: Refactor away this and use aliased actions for less... sloppy
 // flow and make this more reasonable.
 let isReading = false;
 let isSaving = false;
 
-/**
- * Handle triggering actions and related functionality for saving to SAFE netowrk
- * based upon the application stateToSave
- * @param  {Object} state Application state (from redux)
- */
-export const manageReadStateActions = async store => {
-    // Hack as store is actually unreliable.
-    // TODO: Rework this to use aliased funcs.
-    if ( isReading ) {
-        return;
-    }
-
-    const safeBrowserAppState = store.getState().safeBrowserApp;
-
-    // if its not to save, or isnt authed yet...
-    if (
-        safeBrowserAppState.readStatus !== SAFE.READ_STATUS.TO_READ ||
-    safeBrowserAppIsAuthing() ||
-    safeBrowserAppAuthFailed()
-    ) {
-    // do nothing
-        return;
-    }
-
-    if ( !safeBrowserAppIsAuthed() ) {
-    // come back when authed.
-        store.dispatch( safeBrowserAppActions.setAppStatus( SAFE.APP_STATUS.TO_AUTH ) );
-        return;
-    }
-    logger.info( 'Managing a READ action' );
-
-    if ( !safeBrowserAppIsConnected() ) {
-        return;
-    }
-
-    isReading = true;
-
-    logger.info( 'Attempting to READ SafeBrowserApp state from network' );
-    store.dispatch(
-        safeBrowserAppActions.setReadConfigStatus( SAFE.READ_STATUS.READING )
-    );
-
-    readConfigFromSafe( store )
-        .then( savedState => {
-            // store.dispatch( safeBrowserAppActions.receivedConfig( savedState ) );
-            store.dispatch( bookmarksActions.updateBookmarks( savedState ) );
-            store.dispatch( tabsActions.updateTabs( savedState ) );
-            store.dispatch(
-                safeBrowserAppActions.setReadConfigStatus(
-                    SAFE.READ_STATUS.READ_SUCCESSFULLY
-                )
-            );
-
-            isReading = false;
-            return null;
-        } )
-        .catch( e => {
-            isReading = false;
-            logger.error( e );
-            store.dispatch(
-                safeBrowserAppActions.setSaveConfigStatus(
-                    SAFE.SAVE_STATUS.FAILED_TO_READ
-                )
-            );
-            throw new Error( e );
-        } );
-};
-
-/**
- * Handle triggering actions and related functionality for saving to SAFE netowrk
- * based upon the application stateToSave
- * @param  {Object} state Application state (from redux)
- */
-export const manageSaveStateActions = async store => {
-    // Hack as store is actually unreliable.
-    // TODO: Rework this to use aliased funcs.
-    if ( isSaving ) {
-        return;
-    }
-
-    const { safeBrowserApp } = store.getState();
-
-    // if its not to save, or isnt authed yet...
-    if (
-        safeBrowserApp.saveStatus !== SAFE.SAVE_STATUS.TO_SAVE ||
-    safeBrowserAppIsAuthing() ||
-    safeBrowserAppAuthFailed()
-    ) {
-    // do nothing
-        return;
-    }
-
-    // if it auth didnt happen, and hasnt failed...
-    // previously... we can try again (we're in TO SAVE, not SAVING.)
-    if ( !safeBrowserAppIsAuthed() ) {
-    // come back when authed.
-        store.dispatch( safeBrowserAppActions.setAppStatus( SAFE.APP_STATUS.TO_AUTH ) );
-        return;
-    }
-
-    if ( !safeBrowserAppIsConnected() ) {
-        return;
-    }
-
-    // lets scrap read for now.
-    if (
-        safeBrowserApp.readStatus !== SAFE.READ_STATUS.READ_SUCCESSFULLY &&
-    safeBrowserApp.readStatus !== SAFE.READ_STATUS.READ_BUT_NONEXISTANT &&
-    safeBrowserApp.readStatus !== SAFE.READ_STATUS.TO_READ &&
-    safeBrowserApp.readStatus !== SAFE.READ_STATUS.READING
-    ) {
-        logger.info( "Can't save state, not read yet... Triggering a read." );
-        store.dispatch(
-            safeBrowserAppActions.setReadConfigStatus( SAFE.READ_STATUS.TO_READ )
-        );
-
-        return;
-    }
-
-    isSaving = true;
-
-    logger.info( 'Attempting to SAVE SafeBrowserApp state to network' );
-    store.dispatch(
-        safeBrowserAppActions.setSaveConfigStatus( SAFE.SAVE_STATUS.SAVING )
-    );
-    saveConfigToSafe( store )
-        .then( () => {
-            isSaving = false;
-            store.dispatch(
-                safeBrowserAppActions.setSaveConfigStatus(
-                    SAFE.SAVE_STATUS.SAVED_SUCCESSFULLY
-                )
-            );
-
-            return null;
-        } )
-        .catch( e => {
-            isSaving = false;
-            logger.error( e );
-
-            // TODO: Handle errors across the store in a separate error watcher?
-            store.dispatch(
-                safeBrowserAppActions.setSaveConfigStatus(
-                    SAFE.SAVE_STATUS.FAILED_TO_SAVE
-                )
-            );
-            throw new Error( e );
-        } );
-};
+function delay( t ) {
+    return new Promise( ( resolve ) => {
+        setTimeout( resolve, t );
+    } );
+}
 
 /**
  * Parses the browser state to json (removes safeBrowserApp) and saves to an MD on the app Homecontainer,
@@ -201,7 +52,11 @@ export const saveConfigToSafe = ( store, quit ) => {
         let mdEntries;
 
         if ( !safeBrowserAppObject ) {
-            store.dispatch( setSaveConfigStatus( SAFE.SAVE_STATUS.FAILED_TO_SAVE ) );
+            store.dispatch(
+                safeBrowserAppActions.setSaveConfigStatus(
+                    SAFE.SAVE_STATUS.FAILED_TO_SAVE
+                )
+            );
             logger.error( 'Not authorised to save to the network.' );
             return reject( 'Not authorised to save data' );
         }
@@ -268,21 +123,15 @@ export const saveConfigToSafe = ( store, quit ) => {
     } );
 };
 
-function delay( t ) {
-    return new Promise( resolve => {
-        setTimeout( resolve, t );
-    } );
-}
-
 /**
  * Read the configuration from the netowrk
  * @param  {[type]} app SafeApp reference, with handle and authUri
  */
-export const readConfigFromSafe = store =>
+export const readConfigFromSafe = ( store ) =>
     new Promise( async ( resolve, reject ) => {
         const safeBrowserAppObject = getSafeBrowserAppObject();
         if ( !safeBrowserAppObject ) {
-            reject( 'Not authorised to read from the network.' );
+            reject( Error( 'Not authorised to read from the network.' ) );
         }
 
         // FIXME: we add a delay here to prevent a deadlock known in the node-ffi
@@ -316,7 +165,9 @@ export const readConfigFromSafe = store =>
                 }
 
                 store.dispatch(
-                    setReadConfigStatus( SAFE.READ_STATUS.READ_BUT_NONEXISTANT )
+                    safeBrowserAppActions.setReadConfigStatus(
+                        SAFE.READ_STATUS.READ_BUT_NONEXISTANT
+                    )
                 );
             } else {
                 logger.error( e );
@@ -324,3 +175,153 @@ export const readConfigFromSafe = store =>
             }
         }
     } );
+
+/**
+ * Handle triggering actions and related functionality for saving to SAFE netowrk
+ * based upon the application stateToSave
+ * @param  {Object} state Application state (from redux)
+ */
+export const manageReadStateActions = async ( store ) => {
+    // Hack as store is actually unreliable.
+    // TODO: Rework this to use aliased funcs.
+    if ( isReading ) {
+        return;
+    }
+
+    const safeBrowserAppState = store.getState().safeBrowserApp;
+
+    // if its not to save, or isnt authed yet...
+    if (
+        safeBrowserAppState.readStatus !== SAFE.READ_STATUS.TO_READ ||
+    safeBrowserAppIsAuthing() ||
+    safeBrowserAppAuthFailed()
+    ) {
+    // do nothing
+        return;
+    }
+
+    if ( !safeBrowserAppIsAuthed() ) {
+    // come back when authed.
+        store.dispatch( safeBrowserAppActions.setAppStatus( SAFE.APP_STATUS.TO_AUTH ) );
+        return;
+    }
+    logger.info( 'Managing a READ action' );
+
+    if ( !safeBrowserAppIsConnected() ) {
+        return;
+    }
+
+    isReading = true;
+
+    logger.info( 'Attempting to READ SafeBrowserApp state from network' );
+    store.dispatch(
+        safeBrowserAppActions.setReadConfigStatus( SAFE.READ_STATUS.READING )
+    );
+
+    readConfigFromSafe( store )
+        .then( ( savedState ) => {
+            // store.dispatch( safeBrowserAppActions.receivedConfig( savedState ) );
+            store.dispatch( bookmarksActions.updateBookmarks( savedState ) );
+            store.dispatch( tabsActions.updateTabs( savedState ) );
+            store.dispatch(
+                safeBrowserAppActions.setReadConfigStatus(
+                    SAFE.READ_STATUS.READ_SUCCESSFULLY
+                )
+            );
+
+            isReading = false;
+            return null;
+        } )
+        .catch( ( e ) => {
+            isReading = false;
+            logger.error( e );
+            store.dispatch(
+                safeBrowserAppActions.setSaveConfigStatus(
+                    SAFE.SAVE_STATUS.FAILED_TO_READ
+                )
+            );
+            throw new Error( e );
+        } );
+};
+
+/**
+ * Handle triggering actions and related functionality for saving to SAFE netowrk
+ * based upon the application stateToSave
+ * @param  {Object} state Application state (from redux)
+ */
+export const manageSaveStateActions = async ( store ) => {
+    // Hack as store is actually unreliable.
+    // TODO: Rework this to use aliased funcs.
+    if ( isSaving ) {
+        return;
+    }
+
+    const { safeBrowserApp } = store.getState();
+
+    // if its not to save, or isnt authed yet...
+    if (
+        safeBrowserApp.saveStatus !== SAFE.SAVE_STATUS.TO_SAVE ||
+    safeBrowserAppIsAuthing() ||
+    safeBrowserAppAuthFailed()
+    ) {
+    // do nothing
+        return;
+    }
+
+    // if it auth didnt happen, and hasnt failed...
+    // previously... we can try again (we're in TO SAVE, not SAVING.)
+    if ( !safeBrowserAppIsAuthed() ) {
+    // come back when authed.
+        store.dispatch( safeBrowserAppActions.setAppStatus( SAFE.APP_STATUS.TO_AUTH ) );
+        return;
+    }
+
+    if ( !safeBrowserAppIsConnected() ) {
+        return;
+    }
+
+    // lets scrap read for now.
+    if (
+        safeBrowserApp.readStatus !== SAFE.READ_STATUS.READ_SUCCESSFULLY &&
+    safeBrowserApp.readStatus !== SAFE.READ_STATUS.READ_BUT_NONEXISTANT &&
+    safeBrowserApp.readStatus !== SAFE.READ_STATUS.TO_READ &&
+    safeBrowserApp.readStatus !== SAFE.READ_STATUS.READING
+    ) {
+        logger.info( "Can't save state, not read yet... Triggering a read." );
+        store.dispatch(
+            safeBrowserAppActions.setReadConfigStatus( SAFE.READ_STATUS.TO_READ )
+        );
+
+        return;
+    }
+
+    isSaving = true;
+
+    logger.info( 'Attempting to SAVE SafeBrowserApp state to network' );
+    store.dispatch(
+        safeBrowserAppActions.setSaveConfigStatus( SAFE.SAVE_STATUS.SAVING )
+    );
+    saveConfigToSafe( store )
+        .then( () => {
+            isSaving = false;
+            store.dispatch(
+                safeBrowserAppActions.setSaveConfigStatus(
+                    SAFE.SAVE_STATUS.SAVED_SUCCESSFULLY
+                )
+            );
+
+            return null;
+        } )
+        .catch( ( e ) => {
+            isSaving = false;
+            logger.error( e );
+
+            // TODO: Handle errors across the store in a separate error watcher?
+            store.dispatch(
+                safeBrowserAppActions.setSaveConfigStatus(
+                    SAFE.SAVE_STATUS.FAILED_TO_SAVE
+                )
+            );
+            throw new Error( e );
+        } );
+};

--- a/app/menu.ts
+++ b/app/menu.ts
@@ -1,4 +1,5 @@
 import open from 'open';
+import { Store } from 'redux';
 import { app, Menu, BrowserWindow } from 'electron';
 import {
     addTab,
@@ -17,15 +18,22 @@ import { logger } from '$Logger';
 import pkg from '$Package';
 
 import { getExtensionMenuItems } from '$Extensions';
+// import { AppWindow } from '$App/definitions/globals.d';
 
 export class MenuBuilder {
-    constructor( mainWindow: BrowserWindow, openWindow, store ) {
+    private mainWindow: AppWindow;
+
+    private openWindow: Function;
+
+    public store: Store;
+
+    public constructor( mainWindow: AppWindow, openWindow, store ) {
         this.mainWindow = mainWindow;
         this.openWindow = openWindow;
         this.store = store;
     }
 
-    buildMenu() {
+    public buildMenu() {
         if ( isHot ) {
             this.setupDevelopmentEnvironment();
         }
@@ -38,7 +46,7 @@ export class MenuBuilder {
         return menu;
     }
 
-    setupDevelopmentEnvironment() {
+    private setupDevelopmentEnvironment() {
         this.mainWindow.openDevTools();
         this.mainWindow.webContents.on( 'context-menu', ( e, properties ) => {
             const { x, y } = properties;
@@ -54,7 +62,7 @@ export class MenuBuilder {
         } );
     }
 
-    buildMenusTemplate() {
+    private buildMenusTemplate() {
         const { store } = this;
 
         const subMenuAbout = {
@@ -128,13 +136,15 @@ export class MenuBuilder {
                             const state = store.getState();
                             let index;
                             const openTabs = state.tabs.filter(
-                                tab => !tab.isClosed && tab.windowId === windowId
+                                ( tab ) => !tab.isClosed && tab.windowId === windowId
                             );
                             openTabs.forEach( ( tab, i ) => {
                                 if ( tab.isActiveTab ) {
                                     if ( i === openTabs.length - 1 ) {
+                                        // eslint-disable-next-line prefer-destructuring
                                         index = openTabs[0].index;
                                     } else {
+                                        // eslint-disable-next-line prefer-destructuring
                                         index = openTabs[i + 1].index;
                                     }
                                 }
@@ -152,13 +162,15 @@ export class MenuBuilder {
                             const state = store.getState();
                             let index;
                             const openTabs = state.tabs.filter(
-                                tab => !tab.isClosed && tab.windowId === windowId
+                                ( tab ) => !tab.isClosed && tab.windowId === windowId
                             );
                             openTabs.forEach( ( tab, i ) => {
                                 if ( tab.isActiveTab ) {
                                     if ( i === 0 ) {
+                                        // eslint-disable-next-line prefer-destructuring
                                         index = openTabs[openTabs.length - 1].index;
                                     } else {
+                                        // eslint-disable-next-line prefer-destructuring
                                         index = openTabs[i - 1].index;
                                     }
                                 }
@@ -176,7 +188,7 @@ export class MenuBuilder {
                             const windowId = win.webContents.id;
 
                             const openTabs = tabs.filter(
-                                tab => !tab.isClosed && tab.windowId === windowId
+                                ( tab ) => !tab.isClosed && tab.windowId === windowId
                             );
 
                             if ( openTabs.length === 1 ) {
@@ -201,6 +213,8 @@ export class MenuBuilder {
                     accelerator: 'CommandOrControl+Shift+T',
                     click: ( item, win ) => {
                         const lastTab = getLastClosedTab( store.getState().tabs );
+
+                        // TODO properly declare tab type.
                         let windowToFocus = lastTab.windowId;
 
                         if ( windowToFocus ) {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "prettier --ignore-path .eslintignore --arrow-parens always --single-quote --write",
-      "cross-env NODE_ENV=development eslint --cache --format=pretty --fix",
+      "cross-env NODE_ENV=development eslint --cache --format=pretty --fix --ignore-pattern ffi/ --ignore-pattern auth-web-app",
       "git add"
     ],
     "{*.json,.{babelrc,eslintrc,prettierrc,stylelintrc}}": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "esModuleInterop": true,
         "paths": {
             "*": ["app/definitions"],
+            "$App/*": ["app/*"],
             "$Tests/*": ["__tests__/*"],
             "spectron-lib/*": ["__e2e__/lib"],
             "$Actions/*": ["app/actions/*"],


### PR DESCRIPTION
This does some small linting, and sets up the `lint-stage` command to ignore both `FFI`, and `auth-web-app` folders for now (to try and get us on the path to lint checking main browser code first and foremost)

QA: regression tests only.

