### PR TITLE
feat(reload): F5 for reload

### DIFF
--- a/app/menu.ts
+++ b/app/menu.ts
@@ -329,7 +329,8 @@ export class MenuBuilder {
                 { type: 'separator' },
                 {
                     label: 'Reload',
-                    accelerator: 'CommandOrControl+R',
+                    accelerator:
+            process.platform === 'darwin' ? 'CommandOrControl+R' : 'F5',
                     click: ( item, win ) => {
                         if ( win ) {
                             const windowId = win.id;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4400,7 +4400,6 @@ ci-info@^2.0.0:
 
 cids@bochaco/js-cid#temp-use-bochaco-multicodec:
   version "0.5.3"
-  uid fdd908ad57edd5359008adffde1ce32e3e970b15
   resolved "https://codeload.github.com/bochaco/js-cid/tar.gz/fdd908ad57edd5359008adffde1ce32e3e970b15"
   dependencies:
     multibase "~0.4.0"


### PR DESCRIPTION
resolves #596

QA: 
To test this PR 
- Open Safe browser
- For Windows keypress, F5 should reload the page
- For Mac OS keypress Ctrl or Command + R should reload the page


This Issue in electron prevents us from adding more than one keyboard shortcut for a particular menu item.
https://github.com/electron/electron/issues/4758

The issue suggests a workaround for this by handling shortcuts with DOM events
But making this does not work as within the webview the keyboard shortcut does nothing. 
https://github.com/electron/electron/blob/master/docs/tutorial/keyboard-shortcuts.md