### PR TITLE
chore(reload): Change Update Shortcut for reload

### DIFF
--- a/app/components/Tab/Tab.tsx
+++ b/app/components/Tab/Tab.tsx
@@ -120,7 +120,8 @@ export class Tab extends Component<TabProps, TabState> {
             append: ( params ) => [
                 {
                     label: 'Reload',
-                    accelerator: 'CommandOrControl+R',
+                    accelerator:
+            process.platform === 'darwin' ? 'CommandOrControl+R' : 'F5',
                     click() {
                         webview.reload();
                     }


### PR DESCRIPTION
This PR updates the right click menu to show `f5 is the new shortcut to reload a tab for windows and linux, while it is `ctrl+r` for osx