### PR TITLE
chore(favicon): Update path to tab favicon in packaged app

### DIFF
--- a/app/reducers/tabs.ts
+++ b/app/reducers/tabs.ts
@@ -33,7 +33,7 @@ const addTab = ( state, tab ) => {
 
     const faviconPath = isRunningUnpacked
         ? '../resources/favicon.ico'
-        : '../favicon.ico';
+        : '../../favicon.ico';
 
     const newTab = {
         url: tabUrl,


### PR DESCRIPTION
resolves #810 
Path to favicon.ico for tabs in packaged app updated

QA-
To test this PR check if the favicon.ico shows up for both package and unpackaged app