### PR TITLE
chore(tabBar): Update TabBar css to prevent text overflow

### DIFF
--- a/app/components/TabBar/tabBar.css
+++ b/app/components/TabBar/tabBar.css
@@ -10,7 +10,8 @@
     -webkit-app-region: drag;
 }
 .tabRow {
-    flex-wrap: nowrap;
+    display: flex;
+    justify-content: flex-start;
 }
 .containerMac {
     padding-top: 10px;
@@ -42,6 +43,7 @@
 
 .tab {
     composes: tabBox; /* stylelint-disable-line */
+    flex-wrap: nowrap;
     overflow: hidden;
     position: relative;
     max-width: 250px;
@@ -53,6 +55,10 @@
     border-left: none;
 }
 
+.tab .tabRow {
+    flex-flow: nowrap;
+}
+
 .tab:first-child {
     border-left: 1px solid rgba(127, 127, 127, 1);
 }
@@ -62,6 +68,7 @@
 }
 
 .tabText {
+    flex-grow: 2;
     white-space: nowrap;
     overflow: hidden;
     display: inline-block;
@@ -79,6 +86,7 @@
 }
 
 .faviconContainer {
+    flex-wrap: nowrap;
     height: 20px;
     width: 20px;
 }
@@ -89,6 +97,7 @@
 
 .addTab,
 .closeTab {
+    flex-wrap: nowrap;
     padding: 4px;
     border-radius: 100%;
 }


### PR DESCRIPTION
In the packaged app on loading patter, the tab look like :-

![56902837-7b0fea00-6a71-11e9-9154-c164d04d6fd6](https://user-images.githubusercontent.com/31549495/59605488-8788f880-912c-11e9-8ffb-55f199742e7a.png)

This Pr fixes this issue.

QA-
To test this PR package the app and go to safe://patter.dapp