### PR TITLE
chore(package): Provide a AppImage for linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
       "target": "dir"
     },
     "linux": {
-      "target": "dir"
+      "target": ["dir", "AppImage"]
     },
     "mac": {
       "target": "dir"


### PR DESCRIPTION
Packaging the App on Linux should provide an app Image.

QA-
The best way to test this app is to package the app on Linux and check if an AppImage is Provided to as an executable.