### PR TITLE
fix logs on windows

### DIFF
--- a/post-pack.js
+++ b/post-pack.js
@@ -84,6 +84,11 @@ if ( platform === WINDOWS ) {
         CONTAINING_FOLDER,
         'resources'
     );
+    fs.moveSync(
+        path.resolve( PERUSE_RESOURCES_FOLDER, LOGS ),
+        path.resolve( CONTAINING_FOLDER, LOGS ),
+        { overwrite: true }
+    );
     fs.copySync(
         path.resolve( PERUSE_RESOURCES_FOLDER, 'SAFE Browser.crust.config' ),
         path.resolve( CONTAINING_FOLDER, 'SAFE Browser.crust.config' ),
@@ -112,7 +117,7 @@ const removalArray = [
     'LICENSE'
 ];
 
-removalArray.forEach( file => {
+removalArray.forEach( ( file ) => {
     fs.removeSync( `${CONTAINING_FOLDER}/${file}` );
 } );
 


### PR DESCRIPTION
The logs on windows in the `SAFE_Browser.Maidsafe.net_Ltd` was always null and there weren't any logs being added. This was because of the `log.TOML` file was in the packaged apps resources folder rather than in the being in the same directory as the executable. 

QA to test

1. Package the app on windows
2. Launch the app 
3. Login to the authenticator
4. Log out and close the app
5. Check if logs exist in the `SAFE_Browser.Maidsafe.net_Ltd` file 