### PR TITLE
chore(CI): Windows builds with safe-nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - os: osx
       language: node_js
-      rust: 1.3.7
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
@@ -12,7 +11,6 @@ matrix:
 
     - os: linux
       language: node_js
-      rust: 1.3.7
       services:
         - xvfb
       env:
@@ -33,7 +31,6 @@ matrix:
 
     - os: windows
       language: node_js
-      rust: 1.3.7
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
@@ -51,20 +48,6 @@ cache:
     - $(npm config get prefix)/lib/node_modules
     - $HOME/.cache/electron
     - $HOME/.cache/electron-builder
-
-before_install:
-  - |
-    if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.rs
-    chmod +x ./rustup.rs
-    ./rustup.rs -y
-    source $HOME/.cargo/env
-    yarn global add neon-cli
-    fi;
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then PowerShell -Command 'Set-ExecutionPolicy -ExecutionPolicy RemoteSigned'; fi;
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then PowerShell -File internals\\scripts\\install_rustup.ps1; fi;
-  # - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then export CXX="g++-8"; fi
-
 
 install:
   - travis_wait 30 yarn --ignore-engines --network-timeout 800000;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ matrix:
             - xorriso
             - rpm
 
-    # - os: windows
-    #   language: node_js
-    #   rust: 1.3.7
-    #   env:
-    #     - ELECTRON_CACHE=$HOME/.cache/electron
-    #     - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
-    #     - NODE_ENV=dev
-    #     - YARN_GPG=no # otherwise this starts gpg-agent that never exits
+    - os: windows
+      language: node_js
+      rust: 1.3.7
+      env:
+        - ELECTRON_CACHE=$HOME/.cache/electron
+        - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+        - NODE_ENV=dev
+        - YARN_GPG=no # otherwise this starts gpg-agent that never exits
 
 
 before_cache:
@@ -67,7 +67,7 @@ before_install:
 
 
 install:
-  - travis_wait 110 yarn --ignore-engines --network-timeout 800000;
+  - travis_wait 30 yarn --ignore-engines --network-timeout 800000;
   # On Linux, initialize "virtual display". See before_script
 
 


### PR DESCRIPTION
<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Run API playground
- Initialise app
- Copy the value from [authReqWithoutMockBit](https://github.com/maidsafe/safe_browser/compare/master...hunterlester:454?expand=1#diff-a003f29f7e2f9aeecfe6e3fbb39e3d2eR30)
- Paste value into `authorise` operation and run
- Expect to see an error notification
- Same steps for [encodedNonExistentShareMDataReq](https://github.com/maidsafe/safe_browser/compare/master...hunterlester:454?expand=1#diff-a003f29f7e2f9aeecfe6e3fbb39e3d2eR28)

To QA with external app:
- You could use my repo and [set `forceUseMock` to `false` here](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L58), in order to get a `-208` error.
- To test for error `-103`, uncomment [this block](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L60-L68), then replace [authUri here](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L69), with the `shareMDataReqUri` variable.
```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:  
**feat**: New feature  
**fix**: Bug fix  
**docs**: Documentation only changes  
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)  
**refactor**: A code change that neither fixes a bug nor adds a feature  
**perf**: A code change that improves performance  
**test**: Adding missing tests  
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation  
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
