### PR TITLE
feat(releases): use release channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,13 +111,7 @@ after_failure:
 
 
 before_deploy:
-  - |
-    if [[ $TRAVIS_TAG == *"RC"* || $TRAVIS_TAG == *"rc"* ]]; then
-      export IS_RC=yes
-    fi
-  - if [[ "$TRAVIS_OS_NAME" != "windows" && "$IS_RC" == "yes" ]]; then TEST_PACKAGES=true NODE_ENV=prod yarn package; fi
   - ls release
-
 
 deploy:
   provider: releases
@@ -129,4 +123,4 @@ deploy:
   tag_name: $TRAVIS_TAG
   on:
     tags: true
-    branch: dev
+    branch: master

--- a/builderConfig.js
+++ b/builderConfig.js
@@ -50,6 +50,7 @@ const LOGS = 'log.toml';
 
 const buildConfig = {
     appId: 'com.electron.safe-browser',
+    generateUpdatesFilesForAllChannels: true,
     artifactName: `safe-browser-v\${version}-\${os}-x64.\${ext}`,
     afterPack: './afterPack.js',
     afterSign: './afterSign.js',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "safe-browser",
   "identifier": "net.maidsafe.safe-browser",
   "productName": "SAFE Browser",
-  "version": "0.15.3",
+  "version": "0.15.4-alpha",
   "vendor": "MaidSafe.net Ltd",
   "description": "Electron web browser. React/redux powered with an aim of extensiblity.",
   "scripts": {
@@ -13,7 +13,7 @@
     "build-bg": "cross-env NODE_ENV=production webpack --config ./configs/webpack.config.background.prod.babel.js --colors",
     "build-webPreload": "cross-env NODE_ENV=production webpack --config ./configs/webpack.config.web-preload.prod.babel.js --colors",
     "build-renderer": "cross-env NODE_ENV=production webpack --config ./configs/webpack.config.renderer.prod.babel.js --colors",
-    "bump": "standard-version -a",
+    "bump": "git fetch upstream --tags -f || git fetch --tags -f; standard-version -a",
     "check-types": "tsc",
     "prod-dev": "cross-env START_HOT=1 node -r babel-register-ts ./internals/scripts/CheckPortInUse.ts && cross-env NODE_ENV=production START_HOT=1 yarn start-renderer-dev",
     "dev": "yarn mock-dev",


### PR DESCRIPTION
Use release channels, so `-alpha` in package.json will generate alpha releases.

`-beta` beta.

Also updates bump command to pull tags from upstream/origin before doing the bump