### PR TITLE
Warn on safe errors

### DIFF
--- a/app/components/Tab/Tab.tsx
+++ b/app/components/Tab/Tab.tsx
@@ -184,6 +184,7 @@ export class Tab extends Component<TabProps, TabState> {
             ],
             saveImage: false,
             saveImageAs: false,
+            showInspectElement: false,
             showCopyImageAddress: true
         } );
     };

--- a/app/extensions/safe/test/app/saferSafe.spec.ts
+++ b/app/extensions/safe/test/app/saferSafe.spec.ts
@@ -1,0 +1,65 @@
+import { SaferSafe } from '$App/extensions/safe/webviewProcess/saferSafe';
+
+// jest.mock('safe-nodejs');
+
+describe( 'Filesystem safe SAFE', () => {
+    let safe;
+    beforeEach( () => {
+        safe = new SaferSafe();
+    } );
+
+    test( 'a SAFE object has needed methods', async () => {
+        expect( typeof safe.files_container_create ).toBe( 'function' );
+        expect( typeof safe.files_container_add ).toBe( 'function' );
+        expect( typeof safe.files_container_sync ).toBe( 'function' );
+
+        // not strictly needed, but lets check it exists on our new class
+        expect( typeof safe.files_container_add_from_raw ).toBe( 'function' );
+    } );
+
+    test( 'attempting to use location fails', async () => {
+        expect( () => {
+            safe.files_container_create( 'some_location', '', true, true, true );
+        } ).toThrow( /"location"/ );
+        expect( () => {
+            safe.files_container_sync( 'some_location', '', true, true, true );
+        } ).toThrow( /"location"/ );
+        expect( () => {
+            safe.files_container_add( 'some_none_safe_location', '', true, true, true );
+        } ).toThrow( /"location".+safe:/ );
+    } );
+
+    test( 'attempting to use safe container add with a safe: url does not fail', async () => {
+    // it will still fail as args not correct and we're not mocking safe here.
+        expect( () => {
+            safe.files_container_add(
+                'safe://some_safe_location',
+                '',
+                true,
+                true,
+                true
+            );
+        } ).not.toThrow( /"location".+safe:/ );
+    } );
+
+    test( 'attempting to use safe container create should fail when a string is passed', async () => {
+        expect( () => {
+            safe.files_container_create( 's', '', true, true, true );
+        } ).toThrow( /File object/ );
+    } );
+
+    test( 'attempting to use safe container create with locaton object should fail', async () => {
+        const x = {};
+
+        expect( () => {
+            safe.files_container_create( x, '', true, true, true );
+        } ).toThrow( /File object/ );
+    } );
+
+    test( 'attempting to use safe container create with File object should throw temp error', async () => {
+        const x = new File( [], 'test' );
+        expect( () => {
+            safe.files_container_create( x, '', true, true, true );
+        } ).toThrow( /location" argument cannot be used/ );
+    } );
+} );

--- a/app/extensions/safe/webviewProcess/saferSafe.ts
+++ b/app/extensions/safe/webviewProcess/saferSafe.ts
@@ -1,0 +1,94 @@
+import { Safe } from 'safe-nodejs';
+
+/**
+ * Override the nodejs filesystem API to prevent file system access byt apps, and require them to use the browser's File APIs.
+ */
+export class SaferSafe extends Safe {
+    files_container_create = (
+        location?: any,
+        destination?: string,
+        recursive: boolean,
+        del: boolean,
+        updateNrs: boolean,
+        dryRun: boolean
+    ): void => {
+        if ( location && !( location instanceof File ) ) {
+            throw new Error( `
+            "location", if passed, must be a File object.
+            ` );
+        }
+
+        if ( location ) {
+            // Please use "Safe.files_container_create_from_raw" and the native browser "FileReader" API: https://developer.mozilla.org/en-US/docs/Web/API/FileReader
+            throw new Error( `
+            The "location" argument cannot be used on "files_container_create" in the browser yet.
+            ` );
+        }
+
+        return Reflect.apply( Safe.prototype.files_container_create, this, [
+            null,
+            null,
+            del,
+            updateNrs,
+            dryRun
+        ] );
+    };
+
+    files_container_sync = (
+        location?: any,
+        destination?: string,
+        recursive: boolean,
+        del: boolean,
+        updateNrs: boolean,
+        dryRun: boolean
+    ): void => {
+        if ( location && !( location instanceof File ) ) {
+            throw new Error( `
+            "location", if passed, must be a File object.
+            ` );
+        }
+
+        if ( location ) {
+            // TODO: enable Files object use
+            throw new Error( `
+                The "location" argument cannot be used on "files_container_sync" in the browser yet.
+                ` );
+        }
+
+        return Reflect.apply( Safe.prototype.files_container_sync, this, [
+            null,
+            null,
+            del,
+            updateNrs,
+            dryRun
+        ] );
+    };
+
+    files_container_add = (
+        location: string,
+        destination: string,
+        force: boolean,
+        updateNrs: boolean,
+        dryRun: boolean
+    ): void => {
+        if ( typeof location !== 'string' ) {
+            throw new Error( `
+            The "location" must be a "safe:" url string.
+            ` );
+        }
+
+        if ( !location.startsWith( 'safe:' ) ) {
+            throw new Error( `
+                "location" must start with "safe:" 
+                ` );
+        }
+
+        return Reflect.apply( Safe.prototype.files_container_add, this, [
+            location,
+            destination,
+            force,
+            updateNrs,
+            dryRun
+        ] );
+    };
+}

--- a/app/extensions/safe/webviewProcess/webviewPreload.ts
+++ b/app/extensions/safe/webviewProcess/webviewPreload.ts
@@ -1,11 +1,10 @@
 import EventEmitter from 'events';
-import { Safe, XorUrlEncoder } from 'safe-nodejs';
+import { XorUrlEncoder } from 'safe-nodejs';
 
+import { SaferSafe } from '$Extensions/safe/webviewProcess/saferSafe';
 // eslint-disable-next-line import/extensions
 import pkg from '$Package';
 import { logger } from '$Logger';
-// import * as remoteCallActions from '$Actions/remoteCall_actions';
-import { PROTOCOLS, CONFIG, isRunningTestCafeProcess } from '$Constants';
 
 // shim for rdflib.js
 // eslint-disable-next-line no-underscore-dangle
@@ -103,10 +102,11 @@ export const setupWebIdEventEmitter = ( passedStore, win = window ) => {
 
 export const setupSafeAPIs = ( passedStore, win = window ) => {
     const theWindow = win;
-    logger.info( 'Setup up SAFE Dom API...' );
+    logger.info( 'Setup up SAFE Dom API... UPDATED' );
 
     // use from passed object if present (for testing)
-    theWindow.Safe = theWindow.Safe || Safe;
+    theWindow.Safe = theWindow.Safe || SaferSafe;
+
     theWindow.XorUrlEncoder = theWindow.XorUrlEncoder || XorUrlEncoder;
 };
 

--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
     "redux-promise": "0.6.0",
     "redux-promise-middleware": "6.1.2",
     "redux-thunk": "^2.3.0",
-    "safe-nodejs": "https://github.com/maidsafe/safe-nodejs.git#0.8.0",
+    "safe-nodejs": "https://github.com/maidsafe/safe-nodejs.git#0.9.0",
     "source-map-support": "^0.5.16"
   },
   "devEngines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15851,9 +15851,9 @@ safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1,
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
-"safe-nodejs@https://github.com/maidsafe/safe-nodejs.git#0.8.0":
-  version "0.8.0"
-  resolved "https://github.com/maidsafe/safe-nodejs.git#f055398af394fedfc9a9b4767a1a0c6533f7d2ef"
+"safe-nodejs@https://github.com/maidsafe/safe-nodejs.git#0.9.0":
+  version "0.9.0"
+  resolved "https://github.com/maidsafe/safe-nodejs.git#2e056483848d0f1defe845234cfb74889fe34284"
   dependencies:
     add "^2.0.6"
     neon-cli "^0.3.1"


### PR DESCRIPTION
<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Run API playground
- Initialise app
- Copy the value from [authReqWithoutMockBit](https://github.com/maidsafe/safe_browser/compare/master...hunterlester:454?expand=1#diff-a003f29f7e2f9aeecfe6e3fbb39e3d2eR30)
- Paste value into `authorise` operation and run
- Expect to see an error notification
- Same steps for [encodedNonExistentShareMDataReq](https://github.com/maidsafe/safe_browser/compare/master...hunterlester:454?expand=1#diff-a003f29f7e2f9aeecfe6e3fbb39e3d2eR28)

To QA with external app:
- You could use my repo and [set `forceUseMock` to `false` here](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L58), in order to get a `-208` error.
- To test for error `-103`, uncomment [this block](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L60-L68), then replace [authUri here](https://github.com/hunterlester/safe-app-base/blob/master/renderer.js#L69), with the `shareMDataReqUri` variable.
```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:  
**feat**: New feature  
**fix**: Bug fix  
**docs**: Documentation only changes  
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)  
**refactor**: A code change that neither fixes a bug nor adds a feature  
**perf**: A code change that improves performance  
**test**: Adding missing tests  
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation  
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
